### PR TITLE
feat: add support for parsing extensions into custom models

### DIFF
--- a/arazzo/arazzo.go
+++ b/arazzo/arazzo.go
@@ -73,7 +73,6 @@ func Unmarshal(ctx context.Context, doc io.Reader, opts ...Option[unmarshalOptio
 	if err := marshaller.PopulateModel(*c, arazzo); err != nil {
 		return nil, nil, err
 	}
-	arazzo.core = *c
 
 	var validationErrs []error
 	if !o.skipValidation {

--- a/arazzo/arazzo_test.go
+++ b/arazzo/arazzo_test.go
@@ -191,10 +191,10 @@ func TestArazzo_Unmarshal_Success(t *testing.T) {
 	expected := testArazzoInstance
 
 	assert.EqualExportedValues(t, expected, a)
-	assert.Equal(t, expected.Extensions, a.Extensions)
-	assert.Equal(t, expected.Info.Extensions, a.Info.Extensions)
+	assert.EqualExportedValues(t, expected.Extensions, a.Extensions)
+	assert.EqualExportedValues(t, expected.Info.Extensions, a.Info.Extensions)
 	for i, sourceDescription := range expected.SourceDescriptions {
-		assert.Equal(t, sourceDescription.Extensions, a.SourceDescriptions[i].Extensions)
+		assert.EqualExportedValues(t, sourceDescription.Extensions, a.SourceDescriptions[i].Extensions)
 	}
 }
 
@@ -271,10 +271,10 @@ sourceDescriptions:
 	}
 
 	assert.EqualExportedValues(t, expected, a)
-	assert.Equal(t, expected.Extensions, a.Extensions)
-	assert.Equal(t, expected.Info.Extensions, a.Info.Extensions)
+	assert.EqualExportedValues(t, expected.Extensions, a.Extensions)
+	assert.EqualExportedValues(t, expected.Info.Extensions, a.Info.Extensions)
 	for i, sourceDescription := range expected.SourceDescriptions {
-		assert.Equal(t, sourceDescription.Extensions, a.SourceDescriptions[i].Extensions)
+		assert.EqualExportedValues(t, sourceDescription.Extensions, a.SourceDescriptions[i].Extensions)
 	}
 }
 

--- a/arazzo/core/arazzo.go
+++ b/arazzo/core/arazzo.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/speakeasy-api/openapi/extensions/core"
 	"github.com/speakeasy-api/openapi/json"
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/speakeasy-api/openapi/yml"
@@ -17,7 +18,7 @@ type Arazzo struct {
 	SourceDescriptions marshaller.Node[[]SourceDescription] `key:"sourceDescriptions" required:"true"`
 	Workflows          marshaller.Node[[]Workflow]          `key:"workflows" required:"true"`
 	Components         marshaller.Node[*Components]         `key:"components"`
-	Extensions         Extensions                           `key:"extensions"`
+	Extensions         core.Extensions                      `key:"extensions"`
 
 	RootNode *yaml.Node
 	Config   *yml.Config

--- a/arazzo/core/components.go
+++ b/arazzo/core/components.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 
+	coreExtensions "github.com/speakeasy-api/openapi/extensions/core"
 	"github.com/speakeasy-api/openapi/jsonschema/oas31/core"
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/speakeasy-api/openapi/sequencedmap"
@@ -14,7 +15,7 @@ type Components struct {
 	Parameters     marshaller.Node[*sequencedmap.Map[string, Parameter]]       `key:"parameters"`
 	SuccessActions marshaller.Node[*sequencedmap.Map[string, SuccessAction]]   `key:"successActions"`
 	FailureActions marshaller.Node[*sequencedmap.Map[string, FailureAction]]   `key:"failureActions"`
-	Extensions     Extensions                                                  `key:"extensions"`
+	Extensions     coreExtensions.Extensions                                   `key:"extensions"`
 
 	RootNode *yaml.Node
 }

--- a/arazzo/core/criterion.go
+++ b/arazzo/core/criterion.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/speakeasy-api/openapi/extensions/core"
 	"github.com/speakeasy-api/openapi/marshaller"
 	"gopkg.in/yaml.v3"
 )
@@ -86,7 +87,7 @@ type Criterion struct {
 	Context    marshaller.Node[*Expression]        `key:"context"`
 	Condition  marshaller.Node[string]             `key:"condition"`
 	Type       marshaller.Node[CriterionTypeUnion] `key:"type" required:"false"`
-	Extensions Extensions                          `key:"extensions"`
+	Extensions core.Extensions                     `key:"extensions"`
 
 	RootNode *yaml.Node
 }

--- a/arazzo/core/extensions.go
+++ b/arazzo/core/extensions.go
@@ -1,9 +1,0 @@
-package core
-
-import (
-	"github.com/speakeasy-api/openapi/extensions"
-	"github.com/speakeasy-api/openapi/marshaller"
-	"github.com/speakeasy-api/openapi/sequencedmap"
-)
-
-type Extensions = *sequencedmap.Map[string, marshaller.Node[extensions.Extension]]

--- a/arazzo/core/failureaction.go
+++ b/arazzo/core/failureaction.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 
+	"github.com/speakeasy-api/openapi/extensions/core"
 	"github.com/speakeasy-api/openapi/marshaller"
 	"gopkg.in/yaml.v3"
 )
@@ -15,7 +16,7 @@ type FailureAction struct {
 	RetryAfter marshaller.Node[*float64]    `key:"retryAfter"`
 	RetryLimit marshaller.Node[*int]        `key:"retryLimit"`
 	Criteria   marshaller.Node[[]Criterion] `key:"criteria"`
-	Extensions Extensions                   `key:"extensions"`
+	Extensions core.Extensions              `key:"extensions"`
 
 	RootNode *yaml.Node
 }

--- a/arazzo/core/info.go
+++ b/arazzo/core/info.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 
+	"github.com/speakeasy-api/openapi/extensions/core"
 	"github.com/speakeasy-api/openapi/marshaller"
 	"gopkg.in/yaml.v3"
 )
@@ -12,7 +13,7 @@ type Info struct {
 	Summary     marshaller.Node[*string] `key:"summary"`
 	Description marshaller.Node[*string] `key:"description"`
 	Version     marshaller.Node[string]  `key:"version"`
-	Extensions  Extensions               `key:"extensions"`
+	Extensions  core.Extensions          `key:"extensions"`
 
 	RootNode *yaml.Node
 }

--- a/arazzo/core/parameter.go
+++ b/arazzo/core/parameter.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 
+	"github.com/speakeasy-api/openapi/extensions/core"
 	"github.com/speakeasy-api/openapi/marshaller"
 	"gopkg.in/yaml.v3"
 )
@@ -11,7 +12,7 @@ type Parameter struct {
 	Name       marshaller.Node[string]            `key:"name"`
 	In         marshaller.Node[*string]           `key:"in"`
 	Value      marshaller.Node[ValueOrExpression] `key:"value" required:"true"`
-	Extensions Extensions                         `key:"extensions"`
+	Extensions core.Extensions                    `key:"extensions"`
 
 	RootNode *yaml.Node
 }

--- a/arazzo/core/payloadreplacement.go
+++ b/arazzo/core/payloadreplacement.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 
+	"github.com/speakeasy-api/openapi/extensions/core"
 	"github.com/speakeasy-api/openapi/marshaller"
 	"gopkg.in/yaml.v3"
 )
@@ -10,7 +11,7 @@ import (
 type PayloadReplacement struct {
 	Target     marshaller.Node[string]            `key:"target"`
 	Value      marshaller.Node[ValueOrExpression] `key:"value" required:"true"`
-	Extensions Extensions                         `key:"extensions"`
+	Extensions core.Extensions                    `key:"extensions"`
 
 	RootNode *yaml.Node
 }

--- a/arazzo/core/requestbody.go
+++ b/arazzo/core/requestbody.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 
+	"github.com/speakeasy-api/openapi/extensions/core"
 	"github.com/speakeasy-api/openapi/marshaller"
 	"gopkg.in/yaml.v3"
 )
@@ -11,7 +12,7 @@ type RequestBody struct {
 	ContentType  marshaller.Node[*string]              `key:"contentType"`
 	Payload      marshaller.Node[ValueOrExpression]    `key:"payload"`
 	Replacements marshaller.Node[[]PayloadReplacement] `key:"replacements"`
-	Extensions   Extensions                            `key:"extensions"`
+	Extensions   core.Extensions                       `key:"extensions"`
 
 	RootNode *yaml.Node
 }

--- a/arazzo/core/sourcedescription.go
+++ b/arazzo/core/sourcedescription.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 
+	"github.com/speakeasy-api/openapi/extensions/core"
 	"github.com/speakeasy-api/openapi/marshaller"
 	"gopkg.in/yaml.v3"
 )
@@ -11,7 +12,7 @@ type SourceDescription struct {
 	Name       marshaller.Node[string] `key:"name"`
 	URL        marshaller.Node[string] `key:"url"`
 	Type       marshaller.Node[string] `key:"type"`
-	Extensions Extensions              `key:"extensions"`
+	Extensions core.Extensions         `key:"extensions"`
 
 	RootNode *yaml.Node
 }

--- a/arazzo/core/step.go
+++ b/arazzo/core/step.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 
+	"github.com/speakeasy-api/openapi/extensions/core"
 	"github.com/speakeasy-api/openapi/marshaller"
 	"gopkg.in/yaml.v3"
 )
@@ -19,7 +20,7 @@ type Step struct {
 	OnSuccess       marshaller.Node[[]Reusable[SuccessAction]] `key:"onSuccess"`
 	OnFailure       marshaller.Node[[]Reusable[FailureAction]] `key:"onFailure"`
 	Outputs         marshaller.Node[Outputs]                   `key:"outputs"`
-	Extensions      Extensions                                 `key:"extensions"`
+	Extensions      core.Extensions                            `key:"extensions"`
 
 	RootNode *yaml.Node
 }

--- a/arazzo/core/successaction.go
+++ b/arazzo/core/successaction.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 
+	"github.com/speakeasy-api/openapi/extensions/core"
 	"github.com/speakeasy-api/openapi/marshaller"
 	"gopkg.in/yaml.v3"
 )
@@ -13,7 +14,7 @@ type SuccessAction struct {
 	WorkflowID marshaller.Node[*Expression] `key:"workflowId"`
 	StepID     marshaller.Node[*string]     `key:"stepId"`
 	Criteria   marshaller.Node[[]Criterion] `key:"criteria"`
-	Extensions Extensions                   `key:"extensions"`
+	Extensions core.Extensions              `key:"extensions"`
 
 	RootNode *yaml.Node
 }

--- a/arazzo/core/workflow.go
+++ b/arazzo/core/workflow.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 
+	coreExtensions "github.com/speakeasy-api/openapi/extensions/core"
 	"github.com/speakeasy-api/openapi/jsonschema/oas31/core"
 	"github.com/speakeasy-api/openapi/marshaller"
 	"gopkg.in/yaml.v3"
@@ -19,7 +20,7 @@ type Workflow struct {
 	SuccessActions marshaller.Node[[]Reusable[SuccessAction]] `key:"successActions"`
 	FailureActions marshaller.Node[[]Reusable[FailureAction]] `key:"failureActions"`
 	Outputs        marshaller.Node[Outputs]                   `key:"outputs"`
-	Extensions     Extensions                                 `key:"extensions"`
+	Extensions     coreExtensions.Extensions                  `key:"extensions"`
 
 	RootNode *yaml.Node
 }

--- a/extensions/core/extensions.go
+++ b/extensions/core/extensions.go
@@ -1,0 +1,29 @@
+package core
+
+import (
+	"context"
+
+	"github.com/speakeasy-api/openapi/marshaller"
+	"github.com/speakeasy-api/openapi/sequencedmap"
+	"gopkg.in/yaml.v3"
+)
+
+type (
+	Extension  = *yaml.Node
+	Extensions = *sequencedmap.Map[string, marshaller.Node[Extension]]
+)
+
+func UnmarshalExtensionModel[L any](ctx context.Context, e Extensions, ext string) (*L, error) {
+	if !e.Has(ext) {
+		return nil, nil
+	}
+
+	node := e.GetOrZero(ext)
+
+	var l L
+	if err := marshaller.Unmarshal(ctx, node.Value, &l); err != nil {
+		return nil, err
+	}
+
+	return &l, nil
+}

--- a/extensions/core/extensions_test.go
+++ b/extensions/core/extensions_test.go
@@ -1,0 +1,46 @@
+package core_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/speakeasy-api/openapi/extensions/core"
+	"github.com/speakeasy-api/openapi/internal/testutils"
+	"github.com/speakeasy-api/openapi/marshaller"
+	"github.com/speakeasy-api/openapi/sequencedmap"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+type TestCoreModel struct {
+	Name  marshaller.Node[string]     `key:"name"`
+	Value marshaller.Node[*yaml.Node] `key:"value" required:"true"`
+
+	RootNode *yaml.Node
+}
+
+func (t *TestCoreModel) Unmarshal(ctx context.Context, node *yaml.Node) error {
+	t.RootNode = node
+
+	return marshaller.UnmarshalStruct(ctx, node, t)
+}
+
+func TestUnmarshalExtensionModel_Success(t *testing.T) {
+	e := sequencedmap.New(
+		sequencedmap.NewElem("x-speakeasy-test", marshaller.Node[*yaml.Node]{
+			Value: testutils.CreateMapYamlNode([]*yaml.Node{
+				testutils.CreateStringYamlNode("name", 0, 0),
+				testutils.CreateStringYamlNode("test", 0, 0),
+				testutils.CreateStringYamlNode("value", 0, 0),
+				testutils.CreateIntYamlNode(1, 0, 0),
+			}, 0, 0),
+		}),
+	)
+
+	tcm, err := core.UnmarshalExtensionModel[TestCoreModel](context.Background(), e, "x-speakeasy-test")
+	require.NoError(t, err)
+
+	assert.Equal(t, "test", tcm.Name.Value)
+	assert.Equal(t, testutils.CreateIntYamlNode(1, 0, 0), tcm.Value.Value)
+}

--- a/extensions/extensions_test.go
+++ b/extensions/extensions_test.go
@@ -1,0 +1,76 @@
+package extensions_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	"github.com/speakeasy-api/openapi/extensions"
+	coreExtensions "github.com/speakeasy-api/openapi/extensions/core"
+	"github.com/speakeasy-api/openapi/internal/testutils"
+	"github.com/speakeasy-api/openapi/marshaller"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+type ModelWithExtensions struct {
+	Test string
+
+	Extensions *extensions.Extensions
+
+	core CoreModelWithExtensions //nolint:unused
+}
+
+type CoreModelWithExtensions struct {
+	Test       marshaller.Node[string]   `key:"test"`
+	Extensions coreExtensions.Extensions `key:"extensions"`
+
+	RootNode *yaml.Node
+}
+
+type TestModel struct {
+	Name  string
+	Value *yaml.Node
+
+	core TestCoreModel //nolint:unused
+}
+
+type TestCoreModel struct {
+	Name  marshaller.Node[string]     `key:"name"`
+	Value marshaller.Node[*yaml.Node] `key:"value" required:"true"`
+
+	RootNode *yaml.Node
+}
+
+func TestUnmarshalExtensionModel_Success(t *testing.T) {
+	ctx := context.Background()
+
+	data, err := io.ReadAll(bytes.NewReader([]byte(`
+test: hello world
+x-speakeasy-test:
+  name: test
+  value: 1
+`)))
+	require.NoError(t, err)
+
+	var root yaml.Node
+	err = yaml.Unmarshal(data, &root)
+	require.NoError(t, err)
+
+	var c CoreModelWithExtensions
+	err = marshaller.Unmarshal(ctx, &root, &c)
+	require.NoError(t, err)
+
+	m := &ModelWithExtensions{}
+	err = marshaller.PopulateModel(c, m)
+	require.NoError(t, err)
+
+	var testModel TestModel
+	err = extensions.UnmarshalExtensionModel[TestModel, TestCoreModel](ctx, m.Extensions, "x-speakeasy-test", &testModel)
+	require.NoError(t, err)
+
+	assert.Equal(t, "test", testModel.Name)
+	assert.Equal(t, testutils.CreateIntYamlNode(1, 5, 10), testModel.Value)
+}

--- a/jsonschema/oas31/core/discriminator.go
+++ b/jsonschema/oas31/core/discriminator.go
@@ -3,7 +3,7 @@ package core
 import (
 	"context"
 
-	"github.com/speakeasy-api/openapi/extensions"
+	"github.com/speakeasy-api/openapi/extensions/core"
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/speakeasy-api/openapi/sequencedmap"
 	"gopkg.in/yaml.v3"
@@ -12,7 +12,7 @@ import (
 type Discriminator struct {
 	PropertyName marshaller.Node[string]                            `key:"propertyName"`
 	Mapping      marshaller.Node[*sequencedmap.Map[string, string]] `key:"mapping"`
-	Extensions   *extensions.Extensions                             `key:"extensions"`
+	Extensions   core.Extensions                                    `key:"extensions"`
 
 	RootNode *yaml.Node
 }

--- a/jsonschema/oas31/core/extensions.go
+++ b/jsonschema/oas31/core/extensions.go
@@ -1,9 +1,0 @@
-package core
-
-import (
-	"github.com/speakeasy-api/openapi/extensions"
-	"github.com/speakeasy-api/openapi/marshaller"
-	"github.com/speakeasy-api/openapi/sequencedmap"
-)
-
-type Extensions = *sequencedmap.Map[string, marshaller.Node[extensions.Extension]]

--- a/jsonschema/oas31/core/externaldoc.go
+++ b/jsonschema/oas31/core/externaldoc.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 
+	"github.com/speakeasy-api/openapi/extensions/core"
 	"github.com/speakeasy-api/openapi/marshaller"
 	"gopkg.in/yaml.v3"
 )
@@ -10,7 +11,7 @@ import (
 type ExternalDoc struct {
 	Description marshaller.Node[*string] `key:"description"`
 	URL         marshaller.Node[string]  `key:"url"`
-	Extensions  Extensions               `key:"extensions"`
+	Extensions  core.Extensions          `key:"extensions"`
 
 	RootNode *yaml.Node
 }

--- a/jsonschema/oas31/core/jsonschema.go
+++ b/jsonschema/oas31/core/jsonschema.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 
+	"github.com/speakeasy-api/openapi/extensions/core"
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/speakeasy-api/openapi/sequencedmap"
 	"gopkg.in/yaml.v3"
@@ -63,7 +64,7 @@ type Schema struct {
 	Deprecated            marshaller.Node[*bool]                                 `key:"deprecated"`
 	Schema                marshaller.Node[*string]                               `key:"$schema"`
 
-	Extensions Extensions `key:"extensions"`
+	Extensions core.Extensions `key:"extensions"`
 
 	RootNode *yaml.Node
 }

--- a/marshaller/extensions.go
+++ b/marshaller/extensions.go
@@ -8,26 +8,28 @@ import (
 	"slices"
 
 	"github.com/speakeasy-api/openapi/errors"
-	"github.com/speakeasy-api/openapi/extensions"
 	"github.com/speakeasy-api/openapi/yml"
 	"gopkg.in/yaml.v3"
 )
 
+type Extension = *yaml.Node
+
 type ExtensionCoreMap interface {
-	Get(string) (Node[extensions.Extension], bool)
-	Set(string, Node[extensions.Extension])
+	Get(string) (Node[Extension], bool)
+	Set(string, Node[Extension])
 	Delete(string)
-	All() iter.Seq2[string, Node[extensions.Extension]]
+	All() iter.Seq2[string, Node[Extension]]
 	Init()
 }
 
 type ExtensionMap interface {
-	Set(string, extensions.Extension)
+	Set(string, Extension)
 	Init()
+	SetCore(any)
 }
 
 type ExtensionSourceIterator interface {
-	All() iter.Seq2[string, extensions.Extension]
+	All() iter.Seq2[string, Extension]
 }
 
 func unmarshalExtension(keyNode *yaml.Node, valueNode *yaml.Node, extensionsField reflect.Value) error {
@@ -46,7 +48,7 @@ func unmarshalExtension(keyNode *yaml.Node, valueNode *yaml.Node, extensionsFiel
 
 	exts.Init()
 
-	exts.Set(keyNode.Value, Node[extensions.Extension]{
+	exts.Set(keyNode.Value, Node[Extension]{
 		Key:       keyNode.Value,
 		KeyNode:   keyNode,
 		Value:     valueNode,
@@ -83,7 +85,7 @@ func syncExtensions(ctx context.Context, source any, target reflect.Value, mapNo
 		if !ok {
 			keyNode = yml.CreateOrUpdateKeyNode(ctx, key, nil)
 			valueNode = extNode
-			node = Node[extensions.Extension]{
+			node = Node[Extension]{
 				Key:       key,
 				KeyNode:   keyNode,
 				Value:     extNode,

--- a/marshaller/unmarshaller_test.go
+++ b/marshaller/unmarshaller_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/speakeasy-api/openapi/extensions"
 	"github.com/speakeasy-api/openapi/internal/testutils"
 	"github.com/speakeasy-api/openapi/pointer"
 	"github.com/speakeasy-api/openapi/sequencedmap"
@@ -13,7 +12,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-type Extensions = *sequencedmap.Map[string, Node[extensions.Extension]]
+type Extensions = *sequencedmap.Map[string, Node[Extension]]
 
 type TestCoreModel struct {
 	PrimitiveField              Node[string]                                     `key:"primitiveField"`
@@ -80,7 +79,7 @@ x-test-2: some-value-2
 	assertNodeField(t, "sliceRequiredPrimitiveField", 5, []string{"I", "am", "here"}, 5, out.NestedModelField.Value.SliceRequiredPrimitiveField)
 	assertNodeField(t, "mapPrimitiveField", 6, sequencedmap.New(sequencedmap.NewElem("a", 1), sequencedmap.NewElem("b", 2)), 7, out.NestedModelField.Value.MapPrimitiveField)
 	xTestExtensionNodeNestedModelField := testutils.CreateStringYamlNode("some-value", 9, 11)
-	assert.Equal(t, sequencedmap.New(sequencedmap.NewElem("x-test", Node[extensions.Extension]{
+	assert.Equal(t, sequencedmap.New(sequencedmap.NewElem("x-test", Node[Extension]{
 		Key:       "x-test",
 		KeyNode:   testutils.CreateStringYamlNode("x-test", 9, 3),
 		Value:     xTestExtensionNodeNestedModelField,
@@ -101,7 +100,7 @@ x-test-2: some-value-2
 	assertNodeField(t, "slicePrimitiveField", 20, []string{"p", "q", "r"}, 20, out.MapRequiredNestedModelField.Value.GetOrZero("z").SlicePrimitiveField)
 	assertNodeField(t, "sliceRequiredPrimitiveField", 21, []string{"s", "t", "u"}, 21, out.MapRequiredNestedModelField.Value.GetOrZero("z").SliceRequiredPrimitiveField)
 	xTestExtensionNodeMapRequiredNestedModelField := testutils.CreateStringYamlNode("some-value", 22, 13)
-	assert.Equal(t, sequencedmap.New(sequencedmap.NewElem("x-test", Node[extensions.Extension]{
+	assert.Equal(t, sequencedmap.New(sequencedmap.NewElem("x-test", Node[Extension]{
 		Key:       "x-test",
 		KeyNode:   testutils.CreateStringYamlNode("x-test", 22, 5),
 		Value:     xTestExtensionNodeMapRequiredNestedModelField,
@@ -111,7 +110,7 @@ x-test-2: some-value-2
 	assertNodeField(t, "sliceRequiredPrimitiveField", 25, []string{"1", "2", "3"}, 25, out.MapRequiredNestedModelField.Value.GetOrZero("x").SliceRequiredPrimitiveField)
 
 	xTestExtensionNode := testutils.CreateStringYamlNode("some-value-2", 26, 11)
-	assert.Equal(t, sequencedmap.New(sequencedmap.NewElem("x-test-2", Node[extensions.Extension]{
+	assert.Equal(t, sequencedmap.New(sequencedmap.NewElem("x-test-2", Node[Extension]{
 		Key:       "x-test-2",
 		KeyNode:   testutils.CreateStringYamlNode("x-test-2", 26, 1),
 		Value:     xTestExtensionNode,


### PR DESCRIPTION
Add support for a `UnmarshalExtensionModel` method which allows providing custom high/low models for parsing extensions.

This allows for extensions to be handled in a typed manner without custom deserialization logic and retaining the access to the underlying data