### PR TITLE
fix: Support string literal values with spaces in simple conditions

### DIFF
--- a/arazzo/criterion/condition.go
+++ b/arazzo/criterion/condition.go
@@ -44,7 +44,19 @@ func newCondition(rawCondition string) (*Condition, error) {
 		return nil, fmt.Errorf("condition must at least be in the format [expression] [operator] [value]")
 	}
 
-	if len(parts) > 3 || strings.ContainsAny(rawCondition, "&|") {
+	if strings.ContainsAny(rawCondition, "&|") {
+		// TODO this is a complex condition that we don't currently support
+		return nil, nil
+	}
+
+	// String literal value handling (single quotes) until parsing is tokenized.
+	// Reference: https://spec.openapis.org/arazzo/v1.0.0#literals
+	if len(parts) > 3 && strings.HasPrefix(parts[2], "'") && strings.HasSuffix(parts[len(parts)-1], "'") {
+		parts[2] = strings.Join(parts[2:], " ")
+		parts = parts[:3]
+	}
+
+	if len(parts) > 3 {
 		// TODO this is a complex condition that we don't currently support
 		return nil, nil
 	}

--- a/arazzo/criterion/condition_test.go
+++ b/arazzo/criterion/condition_test.go
@@ -1,0 +1,64 @@
+package criterion
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/speakeasy-api/openapi/arazzo/expression"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewCondition(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		raw           string
+		expected      *Condition
+		expectedError error
+	}{
+		"empty string": {
+			raw:      "",
+			expected: nil,
+		},
+		"expression only": {
+			raw:           "$statusCode",
+			expected:      nil,
+			expectedError: fmt.Errorf("condition must at least be in the format [expression] [operator] [value]"),
+		},
+		"expression and operator only": {
+			raw:           "$statusCode ==",
+			expected:      nil,
+			expectedError: fmt.Errorf("condition must at least be in the format [expression] [operator] [value]"),
+		},
+		"$statusCode == 200": {
+			raw: "$statusCode == 200",
+			expected: &Condition{
+				Expression: expression.Expression("$statusCode"),
+				Operator:   OperatorEQ,
+				Value:      "200",
+			},
+		},
+		"$response.body#/test == 'string literal with spaces'": {
+			raw: "$response.body#/test == 'string literal with spaces'",
+			expected: &Condition{
+				Expression: expression.Expression("$response.body#/test"),
+				Operator:   OperatorEQ,
+				Value:      "'string literal with spaces'",
+			},
+		},
+	}
+
+	for testName, testCase := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+
+			actual, actualError := newCondition(testCase.raw)
+
+			if testCase.expectedError != nil {
+				assert.EqualError(t, actualError, testCase.expectedError.Error())
+			}
+
+			assert.EqualExportedValues(t, testCase.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
Reference: https://spec.openapis.org/arazzo/v1.0.0#literals

This enables basic parsing of string literals as values in conditions, which in Arazzo are contained in single quote (') characters.