### PR TITLE
refactor: add helper methods for creating validation errors to remove boilerplate

### DIFF
--- a/arazzo/arazzo.go
+++ b/arazzo/arazzo.go
@@ -158,19 +158,11 @@ func (a *Arazzo) Validate(ctx context.Context, opts ...validation.Option) []erro
 
 	arazzoMajor, arazzoMinor, arazzoPatch, err := parseVersion(a.Arazzo)
 	if err != nil {
-		errs = append(errs, &validation.Error{
-			Message: fmt.Sprintf("invalid Arazzo version in document %s: %s", a.Arazzo, err.Error()),
-			Line:    a.core.Arazzo.GetValueNodeOrRoot(a.core.RootNode).Line,
-			Column:  a.core.Arazzo.GetValueNodeOrRoot(a.core.RootNode).Column,
-		})
+		errs = append(errs, validation.NewValueError(fmt.Sprintf("invalid Arazzo version in document %s: %s", a.Arazzo, err.Error()), a.core, a.core.Arazzo))
 	}
 
 	if arazzoMajor != VersionMajor || arazzoMinor != VersionMinor || arazzoPatch > VersionPatch {
-		errs = append(errs, &validation.Error{
-			Message: fmt.Sprintf("Only Arazzo version %s and below is supported", Version),
-			Line:    a.core.Arazzo.GetValueNodeOrRoot(a.core.RootNode).Line,
-			Column:  a.core.Arazzo.GetValueNodeOrRoot(a.core.RootNode).Column,
-		})
+		errs = append(errs, validation.NewValueError(fmt.Sprintf("only Arazzo version %s and below is supported", Version), a.core, a.core.Arazzo))
 	}
 
 	errs = append(errs, a.Info.Validate(ctx, opts...)...)
@@ -181,11 +173,7 @@ func (a *Arazzo) Validate(ctx context.Context, opts ...validation.Option) []erro
 		errs = append(errs, sourceDescription.Validate(ctx, opts...)...)
 
 		if _, ok := sourceDescriptionNames[sourceDescription.Name]; ok {
-			errs = append(errs, &validation.Error{
-				Message: fmt.Sprintf("sourceDescription name %s is not unique", sourceDescription.Name),
-				Line:    a.core.SourceDescriptions.GetSliceValueNodeOrRoot(i, a.core.RootNode).Line,
-				Column:  a.core.SourceDescriptions.GetSliceValueNodeOrRoot(i, a.core.RootNode).Column,
-			})
+			errs = append(errs, validation.NewSliceError(fmt.Sprintf("sourceDescription name %s is not unique", sourceDescription.Name), a.core, a.core.SourceDescriptions, i))
 		}
 
 		sourceDescriptionNames[sourceDescription.Name] = true
@@ -197,11 +185,7 @@ func (a *Arazzo) Validate(ctx context.Context, opts ...validation.Option) []erro
 		errs = append(errs, workflow.Validate(ctx, opts...)...)
 
 		if _, ok := workflowIds[workflow.WorkflowID]; ok {
-			errs = append(errs, &validation.Error{
-				Message: fmt.Sprintf("workflowId %s is not unique", workflow.WorkflowID),
-				Line:    a.core.Workflows.GetSliceValueNodeOrRoot(i, a.core.RootNode).Line,
-				Column:  a.core.Workflows.GetSliceValueNodeOrRoot(i, a.core.RootNode).Column,
-			})
+			errs = append(errs, validation.NewSliceError(fmt.Sprintf("workflowId %s is not unique", workflow.WorkflowID), a.core, a.core.Workflows, i))
 		}
 
 		workflowIds[workflow.WorkflowID] = true

--- a/arazzo/arazzo_test.go
+++ b/arazzo/arazzo_test.go
@@ -254,7 +254,7 @@ sourceDescriptions:
 
 	assert.Equal(t, []error{
 		&validation.Error{Line: 1, Column: 1, Message: "field workflows is missing"},
-		&validation.Error{Line: 1, Column: 9, Message: "Only Arazzo version 1.0.1 and below is supported"},
+		&validation.Error{Line: 1, Column: 9, Message: "only Arazzo version 1.0.1 and below is supported"},
 		&validation.Error{Line: 4, Column: 3, Message: "field version is missing"},
 		&validation.Error{Line: 6, Column: 5, Message: "field url is missing"},
 		&validation.Error{Line: 7, Column: 11, Message: "type must be one of [openapi, arazzo]"},

--- a/arazzo/components.go
+++ b/arazzo/components.go
@@ -52,11 +52,7 @@ func (c *Components) Validate(ctx context.Context, opts ...validation.Option) []
 
 	for key, input := range c.Inputs.All() {
 		if !componentNameRegex.MatchString(key) {
-			errs = append(errs, &validation.Error{
-				Message: fmt.Sprintf("input key must be a valid key [%s]: %s", componentNameRegex.String(), key),
-				Line:    c.core.Inputs.GetMapKeyNodeOrRoot(key, c.core.RootNode).Line,
-				Column:  c.core.Inputs.GetMapKeyNodeOrRoot(key, c.core.RootNode).Column,
-			})
+			errs = append(errs, validation.NewMapKeyError(fmt.Sprintf("input key must be a valid key [%s]: %s", componentNameRegex.String(), key), c.core, c.core.Inputs, key))
 		}
 
 		if input.IsLeft() {
@@ -68,11 +64,7 @@ func (c *Components) Validate(ctx context.Context, opts ...validation.Option) []
 
 	for key, parameter := range c.Parameters.All() {
 		if !componentNameRegex.MatchString(key) {
-			errs = append(errs, &validation.Error{
-				Message: fmt.Sprintf("parameter key must be a valid key [%s]: %s", componentNameRegex.String(), key),
-				Line:    c.core.Parameters.GetMapKeyNodeOrRoot(key, c.core.RootNode).Line,
-				Column:  c.core.Parameters.GetMapKeyNodeOrRoot(key, c.core.RootNode).Column,
-			})
+			errs = append(errs, validation.NewMapKeyError(fmt.Sprintf("parameter key must be a valid key [%s]: %s", componentNameRegex.String(), key), c.core, c.core.Parameters, key))
 		}
 
 		paramOps := append(opts, validation.WithContextObject(&componentKey{name: key}))
@@ -82,11 +74,7 @@ func (c *Components) Validate(ctx context.Context, opts ...validation.Option) []
 
 	for key, successAction := range c.SuccessActions.All() {
 		if !componentNameRegex.MatchString(key) {
-			errs = append(errs, &validation.Error{
-				Message: fmt.Sprintf("successAction key must be a valid key [%s]: %s", componentNameRegex.String(), key),
-				Line:    c.core.SuccessActions.GetMapKeyNodeOrRoot(key, c.core.RootNode).Line,
-				Column:  c.core.SuccessActions.GetMapKeyNodeOrRoot(key, c.core.RootNode).Column,
-			})
+			errs = append(errs, validation.NewMapKeyError(fmt.Sprintf("successAction key must be a valid key [%s]: %s", componentNameRegex.String(), key), c.core, c.core.SuccessActions, key))
 		}
 
 		successActionOps := append(opts, validation.WithContextObject(&componentKey{name: key}))
@@ -96,11 +84,7 @@ func (c *Components) Validate(ctx context.Context, opts ...validation.Option) []
 
 	for key, failureAction := range c.FailureActions.All() {
 		if !componentNameRegex.MatchString(key) {
-			errs = append(errs, &validation.Error{
-				Message: fmt.Sprintf("failureAction key must be a valid key [%s]: %s", componentNameRegex.String(), key),
-				Line:    c.core.FailureActions.GetMapKeyNodeOrRoot(key, c.core.RootNode).Line,
-				Column:  c.core.FailureActions.GetMapKeyNodeOrRoot(key, c.core.RootNode).Column,
-			})
+			errs = append(errs, validation.NewMapKeyError(fmt.Sprintf("failureAction key must be a valid key [%s]: %s", componentNameRegex.String(), key), c.core, c.core.FailureActions, key))
 		}
 
 		failureActionOps := append(opts, validation.WithContextObject(&componentKey{name: key}))

--- a/arazzo/criterion/criterion.go
+++ b/arazzo/criterion/criterion.go
@@ -67,11 +67,7 @@ func (c *CriterionExpressionType) Validate(opts ...validation.Option) []error {
 		switch c.Version {
 		case CriterionTypeVersionDraftGoesnerDispatchJsonPath00:
 		default:
-			errs = append(errs, &validation.Error{
-				Message: fmt.Sprintf("version must be one of [%s]", strings.Join([]string{string(CriterionTypeVersionDraftGoesnerDispatchJsonPath00)}, ", ")),
-				Line:    c.core.Type.GetValueNodeOrRoot(c.core.RootNode).Line,
-				Column:  c.core.Type.GetValueNodeOrRoot(c.core.RootNode).Column,
-			})
+			errs = append(errs, validation.NewValueError(fmt.Sprintf("version must be one of [%s]", strings.Join([]string{string(CriterionTypeVersionDraftGoesnerDispatchJsonPath00)}, ", ")), c.core, c.core.Type))
 		}
 	case CriterionTypeXPath:
 		switch c.Version {
@@ -79,18 +75,10 @@ func (c *CriterionExpressionType) Validate(opts ...validation.Option) []error {
 		case CriterionTypeVersionXPath20:
 		case CriterionTypeVersionXPath10:
 		default:
-			errs = append(errs, &validation.Error{
-				Message: fmt.Sprintf("version must be one of [%s]", strings.Join([]string{string(CriterionTypeVersionXPath30), string(CriterionTypeVersionXPath20), string(CriterionTypeVersionXPath10)}, ", ")),
-				Line:    c.core.Type.GetValueNodeOrRoot(c.core.RootNode).Line,
-				Column:  c.core.Type.GetValueNodeOrRoot(c.core.RootNode).Column,
-			})
+			errs = append(errs, validation.NewValueError(fmt.Sprintf("version must be one of [%s]", strings.Join([]string{string(CriterionTypeVersionXPath30), string(CriterionTypeVersionXPath20), string(CriterionTypeVersionXPath10)}, ", ")), c.core, c.core.Type))
 		}
 	default:
-		errs = append(errs, &validation.Error{
-			Message: fmt.Sprintf("type must be one of [%s]", strings.Join([]string{string(CriterionTypeJsonPath), string(CriterionTypeXPath)}, ", ")),
-			Line:    c.core.Type.GetValueNodeOrRoot(c.core.RootNode).Line,
-			Column:  c.core.Type.GetValueNodeOrRoot(c.core.RootNode).Column,
-		})
+		errs = append(errs, validation.NewValueError(fmt.Sprintf("type must be one of [%s]", strings.Join([]string{string(CriterionTypeJsonPath), string(CriterionTypeXPath)}, ", ")), c.core, c.core.Type))
 	}
 
 	if len(errs) == 0 {
@@ -218,11 +206,7 @@ func (c *Criterion) Validate(opts ...validation.Option) []error {
 	errs := []error{}
 
 	if c.Condition == "" {
-		errs = append(errs, &validation.Error{
-			Message: "condition is required",
-			Line:    c.core.Condition.GetValueNodeOrRoot(c.core.RootNode).Line,
-			Column:  c.core.Condition.GetValueNodeOrRoot(c.core.RootNode).Column,
-		})
+		errs = append(errs, validation.NewValueError("condition is required", c.core, c.core.Condition))
 	}
 
 	if c.Type.Type != nil {
@@ -232,31 +216,19 @@ func (c *Criterion) Validate(opts ...validation.Option) []error {
 		case CriterionTypeJsonPath:
 		case CriterionTypeXPath:
 		default:
-			errs = append(errs, &validation.Error{
-				Message: fmt.Sprintf("type must be one of [%s]", strings.Join([]string{string(CriterionTypeSimple), string(CriterionTypeRegex), string(CriterionTypeJsonPath), string(CriterionTypeXPath)}, ", ")),
-				Line:    c.core.Type.GetValueNodeOrRoot(c.core.RootNode).Line,
-				Column:  c.core.Type.GetValueNodeOrRoot(c.core.RootNode).Column,
-			})
+			errs = append(errs, validation.NewValueError(fmt.Sprintf("type must be one of [%s]", strings.Join([]string{string(CriterionTypeSimple), string(CriterionTypeRegex), string(CriterionTypeJsonPath), string(CriterionTypeXPath)}, ", ")), c.core, c.core.Type))
 		}
 	} else if c.Type.ExpressionType != nil {
 		errs = append(errs, c.Type.ExpressionType.Validate(opts...)...)
 	}
 
 	if c.Type.IsTypeProvided() && c.Context == nil {
-		errs = append(errs, &validation.Error{
-			Message: "context is required, if type is set",
-			Line:    c.core.Context.GetKeyNodeOrRoot(c.core.RootNode).Line,
-			Column:  c.core.Context.GetKeyNodeOrRoot(c.core.RootNode).Column,
-		})
+		errs = append(errs, validation.NewValueError("context is required, if type is set", c.core, c.core.Context))
 	}
 
 	if c.Context != nil {
 		if err := c.Context.Validate(true); err != nil {
-			errs = append(errs, &validation.Error{
-				Message: err.Error(),
-				Line:    c.core.Context.GetValueNodeOrRoot(c.core.RootNode).Line,
-				Column:  c.core.Context.GetValueNodeOrRoot(c.core.RootNode).Column,
-			})
+			errs = append(errs, validation.NewValueError(err.Error(), c.core, c.core.Context))
 		}
 	}
 
@@ -279,30 +251,18 @@ func (c *Criterion) validateCondition(opts ...validation.Option) []error {
 	case CriterionTypeSimple:
 		cond, err := newCondition(c.Condition)
 		if err != nil && c.Context == nil {
-			errs = append(errs, &validation.Error{
-				Message: err.Error(),
-				Line:    conditionLine,
-				Column:  conditionColumn,
-			})
+			errs = append(errs, validation.NewValueError(err.Error(), c.core, c.core.Condition))
 		} else if cond != nil {
 			errs = append(errs, cond.Validate(conditionLine, conditionColumn, opts...)...)
 		}
 	case CriterionTypeRegex:
 		_, err := regexp.Compile(c.Condition)
 		if err != nil {
-			errs = append(errs, &validation.Error{
-				Message: fmt.Errorf("invalid regex expression: %w", err).Error(),
-				Line:    conditionLine,
-				Column:  conditionColumn,
-			})
+			errs = append(errs, validation.NewValueError(fmt.Errorf("invalid regex expression: %w", err).Error(), c.core, c.core.Condition))
 		}
 	case CriterionTypeJsonPath:
 		if _, err := jsonpath.NewPath(c.Condition); err != nil {
-			errs = append(errs, &validation.Error{
-				Message: fmt.Errorf("invalid jsonpath expression: %w", err).Error(),
-				Line:    conditionLine,
-				Column:  conditionColumn,
-			})
+			errs = append(errs, validation.NewValueError(fmt.Errorf("invalid jsonpath expression: %w", err).Error(), c.core, c.core.Condition))
 		}
 	case CriterionTypeXPath:
 		// TODO validate xpath

--- a/arazzo/failureaction.go
+++ b/arazzo/failureaction.go
@@ -77,42 +77,22 @@ func (f *FailureAction) Validate(ctx context.Context, opts ...validation.Option)
 	errs := []error{}
 
 	if f.core.Name.Present && f.Name == "" {
-		errs = append(errs, &validation.Error{
-			Message: "name is required",
-			Line:    f.core.Name.GetValueNodeOrRoot(f.core.RootNode).Line,
-			Column:  f.core.Name.GetValueNodeOrRoot(f.core.RootNode).Column,
-		})
+		errs = append(errs, validation.NewValueError("name is required", f.core, f.core.Name))
 	}
 
 	switch f.Type {
 	case FailureActionTypeEnd:
 		if f.WorkflowID != nil {
-			errs = append(errs, &validation.Error{
-				Message: "workflowId is not allowed when type: end is specified",
-				Line:    f.core.WorkflowID.GetKeyNodeOrRoot(f.core.RootNode).Line,
-				Column:  f.core.WorkflowID.GetKeyNodeOrRoot(f.core.RootNode).Column,
-			})
+			errs = append(errs, validation.NewValueError("workflowId is not allowed when type: end is specified", f.core, f.core.WorkflowID))
 		}
 		if f.StepID != nil {
-			errs = append(errs, &validation.Error{
-				Message: "stepId is not allowed when type: end is specified",
-				Line:    f.core.StepID.GetKeyNodeOrRoot(f.core.RootNode).Line,
-				Column:  f.core.StepID.GetKeyNodeOrRoot(f.core.RootNode).Column,
-			})
+			errs = append(errs, validation.NewValueError("stepId is not allowed when type: end is specified", f.core, f.core.StepID))
 		}
 		if f.RetryAfter != nil {
-			errs = append(errs, &validation.Error{
-				Message: "retryAfter is not allowed when type: end is specified",
-				Line:    f.core.RetryAfter.GetKeyNodeOrRoot(f.core.RootNode).Line,
-				Column:  f.core.RetryAfter.GetKeyNodeOrRoot(f.core.RootNode).Column,
-			})
+			errs = append(errs, validation.NewValueError("retryAfter is not allowed when type: end is specified", f.core, f.core.RetryAfter))
 		}
 		if f.RetryLimit != nil {
-			errs = append(errs, &validation.Error{
-				Message: "retryLimit is not allowed when type: end is specified",
-				Line:    f.core.RetryLimit.GetKeyNodeOrRoot(f.core.RootNode).Line,
-				Column:  f.core.RetryLimit.GetKeyNodeOrRoot(f.core.RootNode).Column,
-			})
+			errs = append(errs, validation.NewValueError("retryLimit is not allowed when type: end is specified", f.core, f.core.RetryLimit))
 		}
 	case FailureActionTypeGoto:
 		errs = append(errs, validationActionWorkflowIDAndStepID(ctx, validationActionWorkflowStepIDParams{
@@ -128,18 +108,10 @@ func (f *FailureAction) Validate(ctx context.Context, opts ...validation.Option)
 			required:         true,
 		}, opts...)...)
 		if f.RetryAfter != nil {
-			errs = append(errs, &validation.Error{
-				Message: "retryAfter is not allowed when type: goto is specified",
-				Line:    f.core.RetryAfter.GetKeyNodeOrRoot(f.core.RootNode).Line,
-				Column:  f.core.RetryAfter.GetKeyNodeOrRoot(f.core.RootNode).Column,
-			})
+			errs = append(errs, validation.NewValueError("retryAfter is not allowed when type: goto is specified", f.core, f.core.RetryAfter))
 		}
 		if f.RetryLimit != nil {
-			errs = append(errs, &validation.Error{
-				Message: "retryLimit is not allowed when type: goto is specified",
-				Line:    f.core.RetryLimit.GetKeyNodeOrRoot(f.core.RootNode).Line,
-				Column:  f.core.RetryLimit.GetKeyNodeOrRoot(f.core.RootNode).Column,
-			})
+			errs = append(errs, validation.NewValueError("retryLimit is not allowed when type: goto is specified", f.core, f.core.RetryLimit))
 		}
 	case FailureActionTypeRetry:
 		errs = append(errs, validationActionWorkflowIDAndStepID(ctx, validationActionWorkflowStepIDParams{
@@ -156,28 +128,16 @@ func (f *FailureAction) Validate(ctx context.Context, opts ...validation.Option)
 		}, opts...)...)
 		if f.RetryAfter != nil {
 			if *f.RetryAfter < 0 {
-				errs = append(errs, &validation.Error{
-					Message: "retryAfter must be greater than or equal to 0",
-					Line:    f.core.RetryAfter.GetValueNodeOrRoot(f.core.RootNode).Line,
-					Column:  f.core.RetryAfter.GetValueNodeOrRoot(f.core.RootNode).Column,
-				})
+				errs = append(errs, validation.NewValueError("retryAfter must be greater than or equal to 0", f.core, f.core.RetryAfter))
 			}
 		}
 		if f.RetryLimit != nil {
 			if *f.RetryLimit < 0 {
-				errs = append(errs, &validation.Error{
-					Message: "retryLimit must be greater than or equal to 0",
-					Line:    f.core.RetryLimit.GetValueNodeOrRoot(f.core.RootNode).Line,
-					Column:  f.core.RetryLimit.GetValueNodeOrRoot(f.core.RootNode).Column,
-				})
+				errs = append(errs, validation.NewValueError("retryLimit must be greater than or equal to 0", f.core, f.core.RetryLimit))
 			}
 		}
 	default:
-		errs = append(errs, &validation.Error{
-			Message: fmt.Sprintf("type must be one of [%s]", strings.Join([]string{string(FailureActionTypeEnd), string(FailureActionTypeGoto), string(FailureActionTypeRetry)}, ", ")),
-			Line:    f.core.Type.GetValueNodeOrRoot(f.core.RootNode).Line,
-			Column:  f.core.Type.GetValueNodeOrRoot(f.core.RootNode).Column,
-		})
+		errs = append(errs, validation.NewValueError(fmt.Sprintf("type must be one of [%s]", strings.Join([]string{string(FailureActionTypeEnd), string(FailureActionTypeGoto), string(FailureActionTypeRetry)}, ", ")), f.core, f.core.Type))
 	}
 
 	for _, criterion := range f.Criteria {

--- a/arazzo/info.go
+++ b/arazzo/info.go
@@ -41,19 +41,11 @@ func (i *Info) Validate(ctx context.Context, opts ...validation.Option) []error 
 	errs := []error{}
 
 	if i.core.Title.Present && i.Title == "" {
-		errs = append(errs, &validation.Error{
-			Message: "title is required",
-			Line:    i.core.Title.GetValueNodeOrRoot(i.core.RootNode).Line,
-			Column:  i.core.Title.GetValueNodeOrRoot(i.core.RootNode).Column,
-		})
+		errs = append(errs, validation.NewValueError("title is required", i.core, i.core.Title))
 	}
 
 	if i.core.Version.Present && i.Version == "" {
-		errs = append(errs, &validation.Error{
-			Message: "version is required",
-			Line:    i.core.Version.GetValueNodeOrRoot(i.core.RootNode).Line,
-			Column:  i.core.Version.GetValueNodeOrRoot(i.core.RootNode).Column,
-		})
+		errs = append(errs, validation.NewValueError("version is required", i.core, i.core.Version))
 	}
 
 	if len(errs) == 0 {

--- a/arazzo/parameter.go
+++ b/arazzo/parameter.go
@@ -62,11 +62,7 @@ func (p *Parameter) Validate(ctx context.Context, opts ...validation.Option) []e
 	s := validation.GetContextObject[Step](o)
 
 	if p.core.Name.Present && p.Name == "" {
-		errs = append(errs, &validation.Error{
-			Message: "name is required",
-			Line:    p.core.Name.GetValueNodeOrRoot(p.core.RootNode).Line,
-			Column:  p.core.Name.GetValueNodeOrRoot(p.core.RootNode).Column,
-		})
+		errs = append(errs, validation.NewValueError("name is required", p.core, p.core.Name))
 	}
 
 	in := In("")
@@ -82,45 +78,25 @@ func (p *Parameter) Validate(ctx context.Context, opts ...validation.Option) []e
 	default:
 		if p.In == nil || in == "" {
 			if w == nil && s != nil && s.WorkflowID == nil {
-				errs = append(errs, &validation.Error{
-					Message: "in is required within a step when workflowId is not set",
-					Line:    p.core.In.GetValueNodeOrRoot(p.core.RootNode).Line,
-					Column:  p.core.In.GetValueNodeOrRoot(p.core.RootNode).Column,
-				})
+				errs = append(errs, validation.NewValueError("in is required within a step when workflowId is not set", p.core, p.core.In))
 			}
 		}
 
 		if in != "" {
-			errs = append(errs, &validation.Error{
-				Message: fmt.Sprintf("in must be one of [%s] but was %s", strings.Join([]string{string(InPath), string(InQuery), string(InHeader), string(InCookie)}, ", "), in),
-				Line:    p.core.In.GetValueNodeOrRoot(p.core.RootNode).Line,
-				Column:  p.core.In.GetValueNodeOrRoot(p.core.RootNode).Column,
-			})
+			errs = append(errs, validation.NewValueError(fmt.Sprintf("in must be one of [%s] but was %s", strings.Join([]string{string(InPath), string(InQuery), string(InHeader), string(InCookie)}, ", "), in), p.core, p.core.In))
 		}
 	}
 
 	if p.core.Value.Present && p.Value == nil {
-		errs = append(errs, &validation.Error{
-			Message: "value is required",
-			Line:    p.core.Value.GetValueNodeOrRoot(p.core.RootNode).Line,
-			Column:  p.core.Value.GetValueNodeOrRoot(p.core.RootNode).Column,
-		})
+		errs = append(errs, validation.NewValueError("value is required", p.core, p.core.Value))
 	} else if p.Value != nil {
 		_, expression, err := GetValueOrExpressionValue(p.Value)
 		if err != nil {
-			errs = append(errs, &validation.Error{
-				Message: err.Error(),
-				Line:    p.core.Value.GetValueNodeOrRoot(p.core.RootNode).Line,
-				Column:  p.core.Value.GetValueNodeOrRoot(p.core.RootNode).Column,
-			})
+			errs = append(errs, validation.NewValueError(err.Error(), p.core, p.core.Value))
 		}
 		if expression != nil {
 			if err := expression.Validate(true); err != nil {
-				errs = append(errs, &validation.Error{
-					Message: err.Error(),
-					Line:    p.core.Value.GetValueNodeOrRoot(p.core.RootNode).Line,
-					Column:  p.core.Value.GetValueNodeOrRoot(p.core.RootNode).Column,
-				})
+				errs = append(errs, validation.NewValueError(err.Error(), p.core, p.core.Value))
 			}
 		}
 	}

--- a/arazzo/payloadreplacement.go
+++ b/arazzo/payloadreplacement.go
@@ -38,43 +38,23 @@ func (p *PayloadReplacement) Validate(ctx context.Context, opts ...validation.Op
 	errs := []error{}
 
 	if p.core.Target.Present && p.Target == "" {
-		errs = append(errs, &validation.Error{
-			Message: "target is required",
-			Line:    p.core.Target.GetValueNodeOrRoot(p.core.RootNode).Line,
-			Column:  p.core.Target.GetValueNodeOrRoot(p.core.RootNode).Column,
-		})
+		errs = append(errs, validation.NewValueError("target is required", p.core, p.core.Target))
 	}
 
 	if err := p.Target.Validate(); err != nil {
-		errs = append(errs, &validation.Error{
-			Message: err.Error(),
-			Line:    p.core.Target.GetValueNodeOrRoot(p.core.RootNode).Line,
-			Column:  p.core.Target.GetValueNodeOrRoot(p.core.RootNode).Column,
-		})
+		errs = append(errs, validation.NewValueError(err.Error(), p.core, p.core.Target))
 	}
 
 	if p.core.Value.Present && p.Value == nil {
-		errs = append(errs, &validation.Error{
-			Message: "value is required",
-			Line:    p.core.Value.GetValueNodeOrRoot(p.core.RootNode).Line,
-			Column:  p.core.Value.GetValueNodeOrRoot(p.core.RootNode).Column,
-		})
+		errs = append(errs, validation.NewValueError("value is required", p.core, p.core.Value))
 	} else if p.Value != nil {
 		_, expression, err := GetValueOrExpressionValue(p.Value)
 		if err != nil {
-			errs = append(errs, &validation.Error{
-				Message: err.Error(),
-				Line:    p.core.Value.GetValueNodeOrRoot(p.core.RootNode).Line,
-				Column:  p.core.Value.GetValueNodeOrRoot(p.core.RootNode).Column,
-			})
+			errs = append(errs, validation.NewValueError(err.Error(), p.core, p.core.Value))
 		}
 		if expression != nil {
 			if err := expression.Validate(true); err != nil {
-				errs = append(errs, &validation.Error{
-					Message: err.Error(),
-					Line:    p.core.Value.GetValueNodeOrRoot(p.core.RootNode).Line,
-					Column:  p.core.Value.GetValueNodeOrRoot(p.core.RootNode).Column,
-				})
+				errs = append(errs, validation.NewValueError(err.Error(), p.core, p.core.Value))
 			}
 		}
 	}

--- a/arazzo/requestbody.go
+++ b/arazzo/requestbody.go
@@ -45,32 +45,20 @@ func (r *RequestBody) Validate(ctx context.Context, opts ...validation.Option) [
 	if r.ContentType != nil {
 		_, _, err := mime.ParseMediaType(*r.ContentType)
 		if err != nil {
-			errs = append(errs, &validation.Error{
-				Message: fmt.Sprintf("contentType must be valid: %s", err),
-				Line:    r.core.ContentType.GetValueNodeOrRoot(r.core.RootNode).Line,
-				Column:  r.core.ContentType.GetValueNodeOrRoot(r.core.RootNode).Column,
-			})
+			errs = append(errs, validation.NewValueError(fmt.Sprintf("contentType must be valid: %s", err), r.core, r.core.ContentType))
 		}
 	}
 
 	if r.Payload != nil {
 		payloadData, err := yaml.Marshal(r.Payload)
 		if err != nil {
-			errs = append(errs, &validation.Error{
-				Message: err.Error(),
-				Line:    r.core.Payload.GetValueNodeOrRoot(r.core.RootNode).Line,
-				Column:  r.core.Payload.GetValueNodeOrRoot(r.core.RootNode).Column,
-			})
+			errs = append(errs, validation.NewValueError(err.Error(), r.core, r.core.Payload))
 		}
 
 		expressions := expression.ExtractExpressions(string(payloadData))
 		for _, expression := range expressions {
 			if err := expression.Validate(true); err != nil {
-				errs = append(errs, &validation.Error{
-					Message: err.Error(),
-					Line:    r.core.Payload.GetValueNodeOrRoot(r.core.RootNode).Line,
-					Column:  r.core.Payload.GetValueNodeOrRoot(r.core.RootNode).Column,
-				})
+				errs = append(errs, validation.NewValueError(err.Error(), r.core, r.core.Payload))
 			}
 		}
 	}

--- a/arazzo/reusable.go
+++ b/arazzo/reusable.go
@@ -122,11 +122,7 @@ func (r *Reusable[T, V, C]) Validate(ctx context.Context, opts ...validation.Opt
 	case "Parameter":
 	default:
 		if r.Value != nil {
-			errs = append(errs, &validation.Error{
-				Message: "value is not allowed when object is not a parameter",
-				Line:    r.core.Value.GetValueNodeOrRoot(r.core.RootNode).Line,
-				Column:  r.core.Value.GetValueNodeOrRoot(r.core.RootNode).Column,
-			})
+			errs = append(errs, validation.NewValueError("value is not allowed when object is not a parameter", r.core, r.core.Value))
 		}
 	}
 
@@ -146,11 +142,7 @@ func (r *Reusable[T, V, C]) Validate(ctx context.Context, opts ...validation.Opt
 func (r *Reusable[T, V, C]) validateReference(ctx context.Context, a *Arazzo, opts ...validation.Option) []error {
 	if err := r.Reference.Validate(true); err != nil {
 		return []error{
-			validation.Error{
-				Message: err.Error(),
-				Line:    r.core.Reference.GetValueNodeOrRoot(r.core.RootNode).Line,
-				Column:  r.core.Reference.GetValueNodeOrRoot(r.core.RootNode).Column,
-			},
+			validation.NewValueError(err.Error(), r.core, r.core.Reference),
 		}
 	}
 
@@ -158,21 +150,13 @@ func (r *Reusable[T, V, C]) validateReference(ctx context.Context, a *Arazzo, op
 
 	if typ != expression.ExpressionTypeComponents {
 		return []error{
-			validation.Error{
-				Message: fmt.Sprintf("reference must be a components expression, got %s", r.Reference.GetType()),
-				Line:    r.core.Reference.GetValueNodeOrRoot(r.core.RootNode).Line,
-				Column:  r.core.Reference.GetValueNodeOrRoot(r.core.RootNode).Column,
-			},
+			validation.NewValueError(fmt.Sprintf("reference must be a components expression, got %s", r.Reference.GetType()), r.core, r.core.Reference),
 		}
 	}
 
 	if componentType == "" || len(references) != 1 {
 		return []error{
-			validation.Error{
-				Message: fmt.Sprintf("reference must be a components expression with 3 parts, got %s", *r.Reference),
-				Line:    r.core.Reference.GetValueNodeOrRoot(r.core.RootNode).Line,
-				Column:  r.core.Reference.GetValueNodeOrRoot(r.core.RootNode).Column,
-			},
+			validation.NewValueError(fmt.Sprintf("reference must be a components expression with 3 parts, got %s", *r.Reference), r.core, r.core.Reference),
 		}
 	}
 
@@ -180,11 +164,7 @@ func (r *Reusable[T, V, C]) validateReference(ctx context.Context, a *Arazzo, op
 
 	if a.Components == nil {
 		return []error{
-			validation.Error{
-				Message: fmt.Sprintf("components not present, reference to missing component %s", *r.Reference),
-				Line:    r.core.Reference.GetValueNodeOrRoot(r.core.RootNode).Line,
-				Column:  r.core.Reference.GetValueNodeOrRoot(r.core.RootNode).Column,
-			},
+			validation.NewValueError(fmt.Sprintf("components not present, reference to missing component %s", *r.Reference), r.core, r.core.Reference),
 		}
 	}
 
@@ -220,11 +200,7 @@ func (r *Reusable[T, V, C]) validateReference(ctx context.Context, a *Arazzo, op
 		}, opts...)
 	default:
 		return []error{
-			validation.Error{
-				Message: fmt.Sprintf("reference to %s is not valid, valid components are [parameters, successActions, failureActions]", componentType),
-				Line:    r.core.Reference.GetValueNodeOrRoot(r.core.RootNode).Line,
-				Column:  r.core.Reference.GetValueNodeOrRoot(r.core.RootNode).Column,
-			},
+			validation.NewValueError(fmt.Sprintf("reference to %s is not valid, valid components are [parameters, successActions, failureActions]", componentType), r.core, r.core.Reference),
 		}
 	}
 }
@@ -243,32 +219,20 @@ func validateComponentReference[T any, V interfaces.Validator[T]](ctx context.Co
 
 	if args.typ != typ {
 		return []error{
-			validation.Error{
-				Message: fmt.Sprintf("expected a %s reference got %s", typeToComponentType(args.typ), args.componentType),
-				Line:    args.referenceValueNode.Line,
-				Column:  args.referenceValueNode.Column,
-			},
+			validation.NewNodeError(fmt.Sprintf("expected a %s reference got %s", typeToComponentType(args.typ), args.componentType), args.referenceValueNode),
 		}
 	}
 
 	if args.components == nil {
 		return []error{
-			validation.Error{
-				Message: fmt.Sprintf("components.%s not present, reference to missing component %s", args.componentType, *args.reference),
-				Line:    args.referenceValueNode.Line,
-				Column:  args.referenceValueNode.Column,
-			},
+			validation.NewNodeError(fmt.Sprintf("components.%s not present, reference to missing component %s", args.componentType, *args.reference), args.referenceValueNode),
 		}
 	}
 
 	component, ok := args.components.Get(args.componentName)
 	if !ok {
 		return []error{
-			validation.Error{
-				Message: fmt.Sprintf("components.%s.%s not present, reference to missing component %s", args.componentType, args.componentName, *args.reference),
-				Line:    args.referenceValueNode.Line,
-				Column:  args.referenceValueNode.Column,
-			},
+			validation.NewNodeError(fmt.Sprintf("components.%s.%s not present, reference to missing component %s", args.componentType, args.componentName, *args.reference), args.referenceValueNode),
 		}
 	}
 

--- a/arazzo/sourcedescription.go
+++ b/arazzo/sourcedescription.go
@@ -65,26 +65,14 @@ func (s *SourceDescription) Validate(ctx context.Context, opts ...validation.Opt
 	errs := []error{}
 
 	if s.core.Name.Present && s.Name == "" {
-		errs = append(errs, &validation.Error{
-			Message: "name is required",
-			Line:    s.core.Name.GetValueNodeOrRoot(s.core.RootNode).Line,
-			Column:  s.core.Name.GetValueNodeOrRoot(s.core.RootNode).Column,
-		})
+		errs = append(errs, validation.NewValueError("name is required", s.core, s.core.Name))
 	}
 
 	if s.core.URL.Present && s.URL == "" {
-		errs = append(errs, &validation.Error{
-			Message: "url is required",
-			Line:    s.core.URL.GetValueNodeOrRoot(s.core.RootNode).Line,
-			Column:  s.core.URL.GetValueNodeOrRoot(s.core.RootNode).Column,
-		})
+		errs = append(errs, validation.NewValueError("url is required", s.core, s.core.URL))
 	} else if s.core.URL.Present {
 		if _, err := url.Parse(s.URL); err != nil {
-			errs = append(errs, &validation.Error{
-				Message: fmt.Sprintf("url is not a valid url/uri according to RFC 3986: %s", err),
-				Line:    s.core.URL.GetValueNodeOrRoot(s.core.RootNode).Line,
-				Column:  s.core.URL.GetValueNodeOrRoot(s.core.RootNode).Column,
-			})
+			errs = append(errs, validation.NewValueError(fmt.Sprintf("url is not a valid url/uri according to RFC 3986: %s", err), s.core, s.core.URL))
 		}
 	}
 
@@ -92,11 +80,7 @@ func (s *SourceDescription) Validate(ctx context.Context, opts ...validation.Opt
 	case SourceDescriptionTypeOpenAPI:
 	case SourceDescriptionTypeArazzo:
 	default:
-		errs = append(errs, &validation.Error{
-			Message: fmt.Sprintf("type must be one of [%s]", strings.Join([]string{SourceDescriptionTypeOpenAPI, SourceDescriptionTypeArazzo}, ", ")),
-			Line:    s.core.Type.GetValueNodeOrRoot(s.core.RootNode).Line,
-			Column:  s.core.Type.GetValueNodeOrRoot(s.core.RootNode).Column,
-		})
+		errs = append(errs, validation.NewValueError(fmt.Sprintf("type must be one of [%s]", strings.Join([]string{SourceDescriptionTypeOpenAPI, SourceDescriptionTypeArazzo}, ", ")), s.core, s.core.Type))
 	}
 
 	if len(errs) == 0 {

--- a/arazzo/step.go
+++ b/arazzo/step.go
@@ -96,18 +96,10 @@ func (s *Step) Validate(ctx context.Context, opts ...validation.Option) []error 
 	errs := []error{}
 
 	if s.core.StepID.Present && s.StepID == "" {
-		errs = append(errs, &validation.Error{
-			Message: "stepId is required",
-			Line:    s.core.StepID.GetValueNodeOrRoot(s.core.RootNode).Line,
-			Column:  s.core.StepID.GetValueNodeOrRoot(s.core.RootNode).Column,
-		})
+		errs = append(errs, validation.NewValueError("stepId is required", s.core, s.core.StepID))
 	} else if s.StepID != "" {
 		if !stepIDRegex.MatchString(s.StepID) {
-			errs = append(errs, &validation.Error{
-				Message: fmt.Sprintf("stepId must be a valid name [%s]: %s", stepIDRegex.String(), s.StepID),
-				Line:    s.core.StepID.GetValueNodeOrRoot(s.core.RootNode).Line,
-				Column:  s.core.StepID.GetValueNodeOrRoot(s.core.RootNode).Column,
-			})
+			errs = append(errs, validation.NewValueError(fmt.Sprintf("stepId must be a valid name [%s]: %s", stepIDRegex.String(), s.StepID), s.core, s.core.StepID))
 		}
 
 		numStepsWithID := 0
@@ -117,11 +109,7 @@ func (s *Step) Validate(ctx context.Context, opts ...validation.Option) []error 
 			}
 		}
 		if numStepsWithID > 1 {
-			errs = append(errs, &validation.Error{
-				Message: fmt.Sprintf("stepId must be unique within the workflow, found %d steps with the same stepId", numStepsWithID),
-				Line:    s.core.StepID.GetValueNodeOrRoot(s.core.RootNode).Line,
-				Column:  s.core.StepID.GetValueNodeOrRoot(s.core.RootNode).Column,
-			})
+			errs = append(errs, validation.NewValueError(fmt.Sprintf("stepId must be unique within the workflow, found %d steps with the same stepId", numStepsWithID), s.core, s.core.StepID))
 		}
 	}
 
@@ -139,18 +127,10 @@ func (s *Step) Validate(ctx context.Context, opts ...validation.Option) []error 
 	}
 	switch numSet {
 	case 0:
-		errs = append(errs, &validation.Error{
-			Message: "at least one of operationId, operationPath or workflowId must be set",
-			Line:    s.core.RootNode.Line,
-			Column:  s.core.RootNode.Column,
-		})
+		errs = append(errs, validation.NewNodeError("at least one of operationId, operationPath or workflowId must be set", s.core.RootNode))
 	case 1:
 	default:
-		errs = append(errs, &validation.Error{
-			Message: "only one of operationId, operationPath or workflowId can be set",
-			Line:    s.core.RootNode.Line,
-			Column:  s.core.RootNode.Column,
-		})
+		errs = append(errs, validation.NewNodeError("only one of operationId, operationPath or workflowId can be set", s.core.RootNode))
 	}
 
 	if s.OperationID != nil {
@@ -161,118 +141,66 @@ func (s *Step) Validate(ctx context.Context, opts ...validation.Option) []error 
 			}
 		}
 		if numOpenAPISourceDescriptions > 1 && !s.OperationID.IsExpression() {
-			errs = append(errs, &validation.Error{
-				Message: "operationId must be a valid expression if there are multiple OpenAPI source descriptions",
-				Line:    s.core.OperationID.GetValueNodeOrRoot(s.core.RootNode).Line,
-				Column:  s.core.OperationID.GetValueNodeOrRoot(s.core.RootNode).Column,
-			})
+			errs = append(errs, validation.NewValueError("operationId must be a valid expression if there are multiple OpenAPI source descriptions", s.core, s.core.OperationID))
 		}
 		if s.OperationID.IsExpression() {
 			if err := s.OperationID.Validate(false); err != nil {
-				errs = append(errs, &validation.Error{
-					Message: err.Error(),
-					Line:    s.core.OperationID.GetValueNodeOrRoot(s.core.RootNode).Line,
-					Column:  s.core.OperationID.GetValueNodeOrRoot(s.core.RootNode).Column,
-				})
+				errs = append(errs, validation.NewValueError(err.Error(), s.core, s.core.OperationID))
 			}
 
 			typ, sourceDescriptionName, _, _ := s.OperationID.GetParts()
 
 			if typ != expression.ExpressionTypeSourceDescriptions {
-				errs = append(errs, &validation.Error{
-					Message: fmt.Sprintf("operationId must be a sourceDescriptions expression, got %s", typ),
-					Line:    s.core.OperationID.GetValueNodeOrRoot(s.core.RootNode).Line,
-					Column:  s.core.OperationID.GetValueNodeOrRoot(s.core.RootNode).Column,
-				})
+				errs = append(errs, validation.NewValueError(fmt.Sprintf("operationId must be a sourceDescriptions expression, got %s", typ), s.core, s.core.OperationID))
 			}
 
 			if a.SourceDescriptions.Find(string(sourceDescriptionName)) == nil {
-				errs = append(errs, &validation.Error{
-					Message: fmt.Sprintf("sourceDescription %s not found", sourceDescriptionName),
-					Line:    s.core.OperationID.GetValueNodeOrRoot(s.core.RootNode).Line,
-					Column:  s.core.OperationID.GetValueNodeOrRoot(s.core.RootNode).Column,
-				})
+				errs = append(errs, validation.NewValueError(fmt.Sprintf("sourceDescription %s not found", sourceDescriptionName), s.core, s.core.OperationID))
 			}
 		}
 	}
 
 	if s.OperationPath != nil {
 		if err := s.OperationPath.Validate(true); err != nil {
-			errs = append(errs, &validation.Error{
-				Message: err.Error(),
-				Line:    s.core.OperationPath.GetValueNodeOrRoot(s.core.RootNode).Line,
-				Column:  s.core.OperationPath.GetValueNodeOrRoot(s.core.RootNode).Column,
-			})
+			errs = append(errs, validation.NewValueError(err.Error(), s.core, s.core.OperationPath))
 		}
 
 		typ, sourceDescriptionName, expressionParts, jp := s.OperationPath.GetParts()
 
 		if typ != expression.ExpressionTypeSourceDescriptions {
-			errs = append(errs, &validation.Error{
-				Message: fmt.Sprintf("operationPath must be a sourceDescriptions expression, got %s", typ),
-				Line:    s.core.OperationPath.GetValueNodeOrRoot(s.core.RootNode).Line,
-				Column:  s.core.OperationPath.GetValueNodeOrRoot(s.core.RootNode).Column,
-			})
+			errs = append(errs, validation.NewValueError(fmt.Sprintf("operationPath must be a sourceDescriptions expression, got %s", typ), s.core, s.core.OperationPath))
 		}
 
 		if a.SourceDescriptions.Find(string(sourceDescriptionName)) == nil {
-			errs = append(errs, &validation.Error{
-				Message: fmt.Sprintf("sourceDescription %s not found", sourceDescriptionName),
-				Line:    s.core.OperationPath.GetValueNodeOrRoot(s.core.RootNode).Line,
-				Column:  s.core.OperationPath.GetValueNodeOrRoot(s.core.RootNode).Column,
-			})
+			errs = append(errs, validation.NewValueError(fmt.Sprintf("sourceDescription %s not found", sourceDescriptionName), s.core, s.core.OperationPath))
 		}
 
 		if len(expressionParts) != 1 || expressionParts[0] != "url" {
-			errs = append(errs, &validation.Error{
-				Message: "operationPath must reference the url of a sourceDescription",
-				Line:    s.core.OperationPath.GetValueNodeOrRoot(s.core.RootNode).Line,
-				Column:  s.core.OperationPath.GetValueNodeOrRoot(s.core.RootNode).Column,
-			})
+			errs = append(errs, validation.NewValueError("operationPath must reference the url of a sourceDescription", s.core, s.core.OperationPath))
 		}
 		if jp == "" {
-			errs = append(errs, &validation.Error{
-				Message: "operationPath must contain a json pointer to the operation path within the sourceDescription",
-				Line:    s.core.OperationPath.GetValueNodeOrRoot(s.core.RootNode).Line,
-				Column:  s.core.OperationPath.GetValueNodeOrRoot(s.core.RootNode).Column,
-			})
+			errs = append(errs, validation.NewValueError("operationPath must contain a json pointer to the operation path within the sourceDescription", s.core, s.core.OperationPath))
 		}
 	}
 
 	if s.WorkflowID != nil {
 		if s.WorkflowID.IsExpression() {
 			if err := s.WorkflowID.Validate(false); err != nil {
-				errs = append(errs, &validation.Error{
-					Message: err.Error(),
-					Line:    s.core.WorkflowID.GetValueNodeOrRoot(s.core.RootNode).Line,
-					Column:  s.core.WorkflowID.GetValueNodeOrRoot(s.core.RootNode).Column,
-				})
+				errs = append(errs, validation.NewValueError(err.Error(), s.core, s.core.WorkflowID))
 			}
 
 			typ, sourceDescriptionName, _, _ := s.WorkflowID.GetParts()
 
 			if typ != expression.ExpressionTypeSourceDescriptions {
-				errs = append(errs, &validation.Error{
-					Message: fmt.Sprintf("workflowId must be a sourceDescriptions expression, got %s", typ),
-					Line:    s.core.WorkflowID.GetValueNodeOrRoot(s.core.RootNode).Line,
-					Column:  s.core.WorkflowID.GetValueNodeOrRoot(s.core.RootNode).Column,
-				})
+				errs = append(errs, validation.NewValueError(fmt.Sprintf("workflowId must be a sourceDescriptions expression, got %s", typ), s.core, s.core.WorkflowID))
 			}
 
 			if a.SourceDescriptions.Find(string(sourceDescriptionName)) == nil {
-				errs = append(errs, &validation.Error{
-					Message: fmt.Sprintf("sourceDescription %s not found", sourceDescriptionName),
-					Line:    s.core.WorkflowID.GetValueNodeOrRoot(s.core.RootNode).Line,
-					Column:  s.core.WorkflowID.GetValueNodeOrRoot(s.core.RootNode).Column,
-				})
+				errs = append(errs, validation.NewValueError(fmt.Sprintf("sourceDescription %s not found", sourceDescriptionName), s.core, s.core.WorkflowID))
 			}
 		} else {
 			if a.Workflows.Find(string(*s.WorkflowID)) == nil {
-				errs = append(errs, &validation.Error{
-					Message: fmt.Sprintf("workflow %s not found", *s.WorkflowID),
-					Line:    s.core.WorkflowID.GetValueNodeOrRoot(s.core.RootNode).Line,
-					Column:  s.core.WorkflowID.GetValueNodeOrRoot(s.core.RootNode).Column,
-				})
+				errs = append(errs, validation.NewValueError(fmt.Sprintf("workflow %s not found", *s.WorkflowID), s.core, s.core.WorkflowID))
 			}
 		}
 	}
@@ -286,22 +214,14 @@ func (s *Step) Validate(ctx context.Context, opts ...validation.Option) []error 
 		if parameter.Reference != nil {
 			_, ok := parameterRefs[string(*parameter.Reference)]
 			if ok {
-				errs = append(errs, &validation.Error{
-					Message: fmt.Sprintf("duplicate parameter found with reference %s", *parameter.Reference),
-					Line:    s.core.Parameters.GetSliceValueNodeOrRoot(i, s.core.RootNode).Line,
-					Column:  s.core.Parameters.GetSliceValueNodeOrRoot(i, s.core.RootNode).Column,
-				})
+				errs = append(errs, validation.NewSliceError(fmt.Sprintf("duplicate parameter found with reference %s", *parameter.Reference), s.core, s.core.Parameters, i))
 			}
 			parameterRefs[string(*parameter.Reference)] = true
 		} else if parameter.Object != nil {
 			id := fmt.Sprintf("%s.%v", parameter.Object.Name, parameter.Object.In)
 			_, ok := parameters[id]
 			if ok {
-				errs = append(errs, &validation.Error{
-					Message: fmt.Sprintf("duplicate parameter found with name %s and in %v", parameter.Object.Name, parameter.Object.In),
-					Line:    s.core.Parameters.GetSliceValueNodeOrRoot(i, s.core.RootNode).Line,
-					Column:  s.core.Parameters.GetSliceValueNodeOrRoot(i, s.core.RootNode).Column,
-				})
+				errs = append(errs, validation.NewSliceError(fmt.Sprintf("duplicate parameter found with name %s and in %v", parameter.Object.Name, parameter.Object.In), s.core, s.core.Parameters, i))
 			}
 			parameters[id] = true
 		}
@@ -309,11 +229,7 @@ func (s *Step) Validate(ctx context.Context, opts ...validation.Option) []error 
 
 	if s.RequestBody != nil {
 		if s.WorkflowID != nil {
-			errs = append(errs, &validation.Error{
-				Message: "requestBody should not be set when workflowId is set",
-				Line:    s.core.RequestBody.GetValueNodeOrRoot(s.core.RootNode).Line,
-				Column:  s.core.RequestBody.GetValueNodeOrRoot(s.core.RootNode).Column,
-			})
+			errs = append(errs, validation.NewValueError("requestBody should not be set when workflowId is set", s.core, s.core.RequestBody))
 		}
 
 		errs = append(errs, s.RequestBody.Validate(ctx, opts...)...)
@@ -332,22 +248,14 @@ func (s *Step) Validate(ctx context.Context, opts ...validation.Option) []error 
 		if onSuccess.Reference != nil {
 			_, ok := successActionRefs[string(*onSuccess.Reference)]
 			if ok {
-				errs = append(errs, &validation.Error{
-					Message: fmt.Sprintf("duplicate successAction found with reference %s", *onSuccess.Reference),
-					Line:    s.core.OnSuccess.GetSliceValueNodeOrRoot(i, s.core.RootNode).Line,
-					Column:  s.core.OnSuccess.GetSliceValueNodeOrRoot(i, s.core.RootNode).Column,
-				})
+				errs = append(errs, validation.NewSliceError(fmt.Sprintf("duplicate successAction found with reference %s", *onSuccess.Reference), s.core, s.core.OnSuccess, i))
 			}
 			successActionRefs[string(*onSuccess.Reference)] = true
 		} else if onSuccess.Object != nil {
 			id := fmt.Sprintf("%s.%v", onSuccess.Object.Name, onSuccess.Object.Type)
 			_, ok := successActions[id]
 			if ok {
-				errs = append(errs, &validation.Error{
-					Message: fmt.Sprintf("duplicate successAction found with name %s and type %v", onSuccess.Object.Name, onSuccess.Object.Type),
-					Line:    s.core.OnSuccess.GetSliceValueNodeOrRoot(i, s.core.RootNode).Line,
-					Column:  s.core.OnSuccess.GetSliceValueNodeOrRoot(i, s.core.RootNode).Column,
-				})
+				errs = append(errs, validation.NewSliceError(fmt.Sprintf("duplicate successAction found with name %s and type %v", onSuccess.Object.Name, onSuccess.Object.Type), s.core, s.core.OnSuccess, i))
 			}
 			successActions[id] = true
 		}
@@ -362,22 +270,14 @@ func (s *Step) Validate(ctx context.Context, opts ...validation.Option) []error 
 		if onFailure.Reference != nil {
 			_, ok := failureActionRefs[string(*onFailure.Reference)]
 			if ok {
-				errs = append(errs, &validation.Error{
-					Message: fmt.Sprintf("duplicate failureAction found with reference %s", *onFailure.Reference),
-					Line:    s.core.OnFailure.GetSliceValueNodeOrRoot(i, s.core.RootNode).Line,
-					Column:  s.core.OnFailure.GetSliceValueNodeOrRoot(i, s.core.RootNode).Column,
-				})
+				errs = append(errs, validation.NewSliceError(fmt.Sprintf("duplicate failureAction found with reference %s", *onFailure.Reference), s.core, s.core.OnFailure, i))
 			}
 			failureActionRefs[string(*onFailure.Reference)] = true
 		} else if onFailure.Object != nil {
 			id := fmt.Sprintf("%s.%v", onFailure.Object.Name, onFailure.Object.Type)
 			_, ok := failureActions[id]
 			if ok {
-				errs = append(errs, &validation.Error{
-					Message: fmt.Sprintf("duplicate failureAction found with name %s and type %v", onFailure.Object.Name, onFailure.Object.Type),
-					Line:    s.core.OnFailure.GetSliceValueNodeOrRoot(i, s.core.RootNode).Line,
-					Column:  s.core.OnFailure.GetSliceValueNodeOrRoot(i, s.core.RootNode).Column,
-				})
+				errs = append(errs, validation.NewSliceError(fmt.Sprintf("duplicate failureAction found with name %s and type %v", onFailure.Object.Name, onFailure.Object.Type), s.core, s.core.OnFailure, i))
 			}
 			failureActions[id] = true
 		}
@@ -385,19 +285,11 @@ func (s *Step) Validate(ctx context.Context, opts ...validation.Option) []error 
 
 	for name, output := range s.Outputs.All() {
 		if !outputNameRegex.MatchString(name) {
-			errs = append(errs, &validation.Error{
-				Message: fmt.Sprintf("output name must be a valid name [%s]: %s", outputNameRegex.String(), name),
-				Line:    s.core.Outputs.GetMapKeyNodeOrRoot(name, s.core.RootNode).Line,
-				Column:  s.core.Outputs.GetMapKeyNodeOrRoot(name, s.core.RootNode).Column,
-			})
+			errs = append(errs, validation.NewMapKeyError(fmt.Sprintf("output name must be a valid name [%s]: %s", outputNameRegex.String(), name), s.core, s.core.Outputs, name))
 		}
 
 		if err := output.Validate(true); err != nil {
-			errs = append(errs, &validation.Error{
-				Message: err.Error(),
-				Line:    s.core.Outputs.GetMapValueNodeOrRoot(name, s.core.RootNode).Line,
-				Column:  s.core.Outputs.GetMapValueNodeOrRoot(name, s.core.RootNode).Column,
-			})
+			errs = append(errs, validation.NewMapValueError(err.Error(), s.core, s.core.Outputs, name))
 		}
 	}
 

--- a/arazzo/successaction.go
+++ b/arazzo/successaction.go
@@ -69,28 +69,16 @@ func (s *SuccessAction) Validate(ctx context.Context, opts ...validation.Option)
 	errs := []error{}
 
 	if s.core.Name.Present && s.Name == "" {
-		errs = append(errs, &validation.Error{
-			Message: "name is required",
-			Line:    s.core.Name.GetValueNodeOrRoot(s.core.RootNode).Line,
-			Column:  s.core.Name.GetValueNodeOrRoot(s.core.RootNode).Column,
-		})
+		errs = append(errs, validation.NewValueError("name is required", s.core, s.core.Name))
 	}
 
 	switch s.Type {
 	case SuccessActionTypeEnd:
 		if s.WorkflowID != nil {
-			errs = append(errs, &validation.Error{
-				Message: "workflowId is not allowed when type: end is specified",
-				Line:    s.core.WorkflowID.GetKeyNodeOrRoot(s.core.RootNode).Line,
-				Column:  s.core.WorkflowID.GetKeyNodeOrRoot(s.core.RootNode).Column,
-			})
+			errs = append(errs, validation.NewValueError("workflowId is not allowed when type: end is specified", s.core, s.core.WorkflowID))
 		}
 		if s.StepID != nil {
-			errs = append(errs, &validation.Error{
-				Message: "stepId is not allowed when type: end is specified",
-				Line:    s.core.StepID.GetKeyNodeOrRoot(s.core.RootNode).Line,
-				Column:  s.core.StepID.GetKeyNodeOrRoot(s.core.RootNode).Column,
-			})
+			errs = append(errs, validation.NewValueError("stepId is not allowed when type: end is specified", s.core, s.core.StepID))
 		}
 	case SuccessActionTypeGoto:
 		errs = append(errs, validationActionWorkflowIDAndStepID(ctx, validationActionWorkflowStepIDParams{
@@ -106,11 +94,7 @@ func (s *SuccessAction) Validate(ctx context.Context, opts ...validation.Option)
 			required:         true,
 		}, opts...)...)
 	default:
-		errs = append(errs, &validation.Error{
-			Message: fmt.Sprintf("type must be one of [%s]", strings.Join([]string{string(SuccessActionTypeEnd), string(SuccessActionTypeGoto)}, ", ")),
-			Line:    s.core.Type.GetValueNodeOrRoot(s.core.RootNode).Line,
-			Column:  s.core.Type.GetValueNodeOrRoot(s.core.RootNode).Column,
-		})
+		errs = append(errs, validation.NewValueError(fmt.Sprintf("type must be one of [%s]", strings.Join([]string{string(SuccessActionTypeEnd), string(SuccessActionTypeGoto)}, ", ")), s.core, s.core.Type))
 	}
 
 	for _, criterion := range s.Criteria {

--- a/jsonschema/oas31/validation.go
+++ b/jsonschema/oas31/validation.go
@@ -30,22 +30,14 @@ func (js *Schema) Validate(ctx context.Context, opts ...validation.Option) []err
 
 	if err := json.YAMLToJSON(js.core.RootNode, 0, buf); err != nil {
 		return []error{
-			validation.Error{
-				Message: err.Error(),
-				Line:    js.core.RootNode.Line,
-				Column:  js.core.RootNode.Column,
-			},
+			validation.NewNodeError(err.Error(), js.core.RootNode),
 		}
 	}
 
 	jsAny, err := jsValidator.UnmarshalJSON(buf)
 	if err != nil {
 		return []error{
-			validation.Error{
-				Message: err.Error(),
-				Line:    js.core.RootNode.Line,
-				Column:  js.core.RootNode.Column,
-			},
+			validation.NewNodeError(err.Error(), js.core.RootNode),
 		}
 	}
 
@@ -56,11 +48,7 @@ func (js *Schema) Validate(ctx context.Context, opts ...validation.Option) []err
 			return getRootCauses(validationErr, js.core)
 		} else {
 			return []error{
-				validation.Error{
-					Message: err.Error(),
-					Line:    js.core.RootNode.Line,
-					Column:  js.core.RootNode.Column,
-				},
+				validation.NewNodeError(err.Error(), js.core.RootNode),
 			}
 		}
 	}
@@ -93,11 +81,7 @@ func getRootCauses(err *jsValidator.ValidationError, js core.Schema) []error {
 				panic(errors.New("expected marshallerNode"))
 			}
 
-			errs = append(errs, &validation.Error{
-				Message: "jsonschema validation error: " + cause.Error(),
-				Line:    mn.GetKeyNodeOrRoot(js.RootNode).Line,
-				Column:  mn.GetKeyNodeOrRoot(js.RootNode).Column,
-			})
+			errs = append(errs, validation.NewNodeError("jsonschema validation error: "+cause.Error(), mn.GetKeyNodeOrRoot(js.RootNode)))
 		} else {
 			errs = append(errs, getRootCauses(cause, js)...)
 		}

--- a/marshaller/unmarshaller.go
+++ b/marshaller/unmarshaller.go
@@ -147,11 +147,7 @@ func UnmarshalModel(ctx context.Context, node *yaml.Node, structPtr any) error {
 		}
 
 		if _, ok := foundFields.Get(key); !ok {
-			validation.AddValidationError(ctx, &validation.Error{
-				Message: fmt.Sprintf("field %s is missing", key),
-				Line:    node.Line,
-				Column:  node.Column,
-			})
+			validation.AddValidationError(ctx, validation.NewNodeError(fmt.Sprintf("field %s is missing", key), node))
 		}
 	}
 

--- a/validation/errors.go
+++ b/validation/errors.go
@@ -2,6 +2,9 @@ package validation
 
 import (
 	"fmt"
+	"reflect"
+
+	"gopkg.in/yaml.v3"
 )
 
 // Error represents a validation error and the line and column where it occurred
@@ -14,4 +17,120 @@ type Error struct {
 
 func (e Error) Error() string {
 	return fmt.Sprintf("[%d:%d] %s", e.Line, e.Column, e.Message)
+}
+
+type valueNodeGetter interface {
+	GetValueNodeOrRoot(root *yaml.Node) *yaml.Node
+}
+
+type sliceNodeGetter interface {
+	GetSliceValueNodeOrRoot(index int, root *yaml.Node) *yaml.Node
+}
+
+type mapKeyNodeGetter interface {
+	GetMapKeyNodeOrRoot(key string, root *yaml.Node) *yaml.Node
+}
+
+type mapValueNodeGetter interface {
+	GetMapValueNodeOrRoot(key string, root *yaml.Node) *yaml.Node
+}
+
+func NewNodeError(msg string, node *yaml.Node) error {
+	return &Error{
+		Message: msg,
+		Line:    node.Line,
+		Column:  node.Column,
+	}
+}
+
+func NewValueError(msg string, core any, node valueNodeGetter) error {
+	// Use reflection to get the RootNode field from the core model
+	v := reflect.ValueOf(core)
+	rootNodeField := v.FieldByName("RootNode")
+
+	if !rootNodeField.IsValid() || rootNodeField.IsNil() {
+		// Fallback if RootNode is not available
+		return &Error{
+			Message: msg,
+			// Default to line 0, column 0 if we can't get location info
+		}
+	}
+
+	rootNode := rootNodeField.Interface().(*yaml.Node)
+	valueNode := node.GetValueNodeOrRoot(rootNode)
+
+	return &Error{
+		Message: msg,
+		Line:    valueNode.Line,
+		Column:  valueNode.Column,
+	}
+}
+
+func NewSliceError(msg string, core any, node sliceNodeGetter, index int) error {
+	// Use reflection to get the RootNode field from the core model
+	v := reflect.ValueOf(core)
+	rootNodeField := v.FieldByName("RootNode")
+
+	if !rootNodeField.IsValid() || rootNodeField.IsNil() {
+		// Fallback if RootNode is not available
+		return &Error{
+			Message: msg,
+			// Default to line 0, column 0 if we can't get location info
+		}
+	}
+
+	rootNode := rootNodeField.Interface().(*yaml.Node)
+	valueNode := node.GetSliceValueNodeOrRoot(index, rootNode)
+
+	return &Error{
+		Message: msg,
+		Line:    valueNode.Line,
+		Column:  valueNode.Column,
+	}
+}
+
+func NewMapKeyError(msg string, core any, node mapKeyNodeGetter, key string) error {
+	// Use reflection to get the RootNode field from the core model
+	v := reflect.ValueOf(core)
+	rootNodeField := v.FieldByName("RootNode")
+
+	if !rootNodeField.IsValid() || rootNodeField.IsNil() {
+		// Fallback if RootNode is not available
+		return &Error{
+			Message: msg,
+			// Default to line 0, column 0 if we can't get location info
+		}
+	}
+
+	rootNode := rootNodeField.Interface().(*yaml.Node)
+	valueNode := node.GetMapKeyNodeOrRoot(key, rootNode)
+
+	return &Error{
+		Message: msg,
+		Line:    valueNode.Line,
+		Column:  valueNode.Column,
+	}
+}
+
+func NewMapValueError(msg string, core any, node mapValueNodeGetter, key string) error {
+	// Use reflection to get the RootNode field from the core model
+	v := reflect.ValueOf(core)
+	rootNodeField := v.FieldByName("RootNode")
+
+	if !rootNodeField.IsValid() || rootNodeField.IsNil() {
+		// Fallback if RootNode is not available
+		return &Error{
+			Message: msg,
+			// Default to line 0, column 0 if we can't get location info
+		}
+	}
+
+	rootNode := rootNodeField.Interface().(*yaml.Node)
+	valueNode := node.GetMapValueNodeOrRoot(key, rootNode)
+
+	return &Error{
+		Message: msg,
+		Line:    valueNode.Line,
+		Column:  valueNode.Column,
+	}
 }


### PR DESCRIPTION
This pull request refactors validation error handling across multiple files in the `arazzo` package. The changes replace direct instantiation of `validation.Error` objects with specialized constructors (`validation.NewValueError`, `validation.NewSliceError`, and `validation.NewMapKeyError`) to streamline error creation and improve consistency. Additionally, minor adjustments to error messages are included.

### Refactoring Validation Error Handling

#### Value Errors:
* [`arazzo/arazzo.go`](diffhunk://#diff-f34e45553efd646acc28471b0837df2dd38b7792f5c7b05174fbd4030c69bbf1L161-R165): Replaced direct `validation.Error` instantiation with `validation.NewValueError` for version validation errors. [[1]](diffhunk://#diff-f34e45553efd646acc28471b0837df2dd38b7792f5c7b05174fbd4030c69bbf1L161-R165) [[2]](diffhunk://#diff-4f796f8c619747972070716649705e34826362dd68955cbad512f9c150bdbebbL70-R81)
* [`arazzo/criterion/criterion.go`](diffhunk://#diff-4f796f8c619747972070716649705e34826362dd68955cbad512f9c150bdbebbL221-R209): Updated validation logic to use `validation.NewValueError` for type and version checks, and for errors related to conditions and contexts. [[1]](diffhunk://#diff-4f796f8c619747972070716649705e34826362dd68955cbad512f9c150bdbebbL221-R209) [[2]](diffhunk://#diff-4f796f8c619747972070716649705e34826362dd68955cbad512f9c150bdbebbL235-R231) [[3]](diffhunk://#diff-4f796f8c619747972070716649705e34826362dd68955cbad512f9c150bdbebbL282-R265)
* [`arazzo/failureaction.go`](diffhunk://#diff-e0bf47f016b67f407c3afc4510acb3937e6b664af952dda8045b1c8fc14f3559L80-R95): Refactored validation errors for `FailureAction` to use `validation.NewValueError` for required fields and invalid configurations. [[1]](diffhunk://#diff-e0bf47f016b67f407c3afc4510acb3937e6b664af952dda8045b1c8fc14f3559L80-R95) [[2]](diffhunk://#diff-e0bf47f016b67f407c3afc4510acb3937e6b664af952dda8045b1c8fc14f3559L159-R140)
* [`arazzo/info.go`](diffhunk://#diff-6eb50b347982d65a9c6e4e9cad8c8e53e0b58ce51675e9dca8a7b00b9729f078L44-R48): Changed title and version validation errors to use `validation.NewValueError`.
* [`arazzo/parameter.go`](diffhunk://#diff-6f423332ce8c0957495b2e553c16eff7e93d33287c1bb3216fb2ff948529395fL65-R65): Updated parameter name validation to use `validation.NewValueError`.

#### Slice Errors:
* [`arazzo/arazzo.go`](diffhunk://#diff-f34e45553efd646acc28471b0837df2dd38b7792f5c7b05174fbd4030c69bbf1L184-R176): Replaced `validation.Error` with `validation.NewSliceError` for errors related to unique names in source descriptions and workflows. [[1]](diffhunk://#diff-f34e45553efd646acc28471b0837df2dd38b7792f5c7b05174fbd4030c69bbf1L184-R176) [[2]](diffhunk://#diff-f34e45553efd646acc28471b0837df2dd38b7792f5c7b05174fbd4030c69bbf1L200-R188)

#### Map Key Errors:
* [`arazzo/components.go`](diffhunk://#diff-52926e4b17578b9424c164ed5ea7999bd598ee3de7462eb10133bf87bb755823L55-R55): Refactored validation errors for invalid keys in components (`Inputs`, `Parameters`, `SuccessActions`, `FailureActions`) to use `validation.NewMapKeyError`. [[1]](diffhunk://#diff-52926e4b17578b9424c164ed5ea7999bd598ee3de7462eb10133bf87bb755823L55-R55) [[2]](diffhunk://#diff-52926e4b17578b9424c164ed5ea7999bd598ee3de7462eb10133bf87bb755823L71-R67) [[3]](diffhunk://#diff-52926e4b17578b9424c164ed5ea7999bd598ee3de7462eb10133bf87bb755823L85-R77) [[4]](diffhunk://#diff-52926e4b17578b9424c164ed5ea7999bd598ee3de7462eb10133bf87bb755823L99-R87)

### Minor Adjustments to Error Messages
* [`arazzo/arazzo_test.go`](diffhunk://#diff-96299b6541c0b1b1566c860cdb74c89766adb0846d9cde3cdead5bf443fcef3cL257-R257): Standardized error message capitalization for consistency.