### PR TITLE
fix: enhance CLI version detection with build info fallback and fix SBOM generation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,6 +30,10 @@ jobs:
       - name: Run tests
         run: mise run test
 
+      - name: Install syft for SBOM generation
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:


### PR DESCRIPTION
# Fix CLI Version Detection and Release Workflow SBOM Generation

## Problem

1. **CLI Version Detection**: The CLI only showed version information when built with GoReleaser ldflags, but `go install` builds showed minimal version info
2. **Release Workflow Failure**: GoReleaser workflow was failing with `syft: executable file not found in $PATH` when generating SBOMs

## Solution

### Enhanced CLI Version Detection
- **Smart Priority System**: 
  1. Uses GoReleaser ldflags values (for official releases)
  2. Falls back to `runtime/debug.ReadBuildInfo()` (for `go install` builds)
  3. Shows "dev" for development builds
- **Automatic Git Information**: Extracts module version, commit hash, and build timestamp from VCS when available
- **Backward Compatibility**: Maintains full compatibility with existing GoReleaser release process

### Fixed Release Workflow
- Added `syft` installation step to GitHub Actions workflow
- Ensures SBOM generation works correctly during releases

## Changes

- `cmd/openapi/main.go`: Enhanced version detection with `runtime/debug.ReadBuildInfo()` fallback
- `.github/workflows/release.yaml`: Added syft installation for SBOM generation

## Testing

- ✅ `go run ./cmd/openapi --version` → Shows "dev"
- ✅ `go install ./cmd/openapi && openapi --version` → Shows rich version info with Git details
- ✅ GoReleaser ldflags override → Prioritizes release version information
- ✅ Linting passes with `mise lint`

## Version Output Examples

**Released binaries (GoReleaser):**
```
v2.0.0
Build: release123
Built: 2025-08-19T04:00:00Z
```

**`go install` builds:**
```
v1.1.0+dirty
Build: 5e2328d
Built: 2025-08-19T03:45:25Z
```

**Development builds:**
```
dev