### PR TITLE
fix: improve openapi join conflict resolution and validation

### DIFF
--- a/jsonschema/oas3/resolution.go
+++ b/jsonschema/oas3/resolution.go
@@ -27,6 +27,7 @@ func (s *JSONSchema[Referenceable]) IsResolved() bool {
 	return !s.IsReference() || s.resolvedSchemaCache != nil || (s.referenceResolutionCache != nil && s.referenceResolutionCache.Object != nil) || s.circularErrorFound
 }
 
+// IsReference returns true if the JSONSchema is a reference, false otherwise
 func (j *JSONSchema[Referenceable]) IsReference() bool {
 	if j == nil || j.IsRight() {
 		return false
@@ -35,6 +36,18 @@ func (j *JSONSchema[Referenceable]) IsReference() bool {
 	return j.GetLeft().IsReference()
 }
 
+// GetReference returns the reference of the JSONSchema if present, otherwise an empty string
+// This method is identical to GetRef() but was added to support the Resolvable interface
+func (j *JSONSchema[Referenceable]) GetReference() references.Reference {
+	if j == nil {
+		return ""
+	}
+
+	return j.GetRef()
+}
+
+// GetRef returns the reference of the JSONSchema if present, otherwise an empty string
+// This method is identical to GetReference() but was kept for backwards compatibility
 func (j *JSONSchema[Referenceable]) GetRef() references.Reference {
 	if j == nil || j.IsRight() {
 		return ""
@@ -43,6 +56,7 @@ func (j *JSONSchema[Referenceable]) GetRef() references.Reference {
 	return j.GetLeft().GetRef()
 }
 
+// GetAbsRef returns the absolute reference of the JSONSchema if present, otherwise an empty string
 func (j *JSONSchema[Referenceable]) GetAbsRef() references.Reference {
 	if !j.IsReference() {
 		return ""

--- a/jsonschema/oas3/schema_validate_test.go
+++ b/jsonschema/oas3/schema_validate_test.go
@@ -415,7 +415,7 @@ additionalProperties: "invalid"
 `,
 			wantErrs: []string{
 				"schema field additionalProperties got string, want boolean or object",
-				"schema expected object, got scalar",
+				"schema.additionalProperties expected object, got scalar",
 			},
 		},
 		{
@@ -442,7 +442,7 @@ items: "invalid"
 `,
 			wantErrs: []string{
 				"schema field items got string, want boolean or object",
-				"schema expected object, got scalar",
+				"schema.items expected object, got scalar",
 			},
 		},
 		{

--- a/marshaller/unmarshaller.go
+++ b/marshaller/unmarshaller.go
@@ -383,7 +383,7 @@ func unmarshalModel(ctx context.Context, node *yaml.Node, structPtr any) ([]erro
 				fieldVal := out.Field(fieldIndex)
 
 				if implementsInterface(fieldVal, nodeMutatorType) {
-					fieldValidationErrs, err := unmarshalNode(ctx, modelTag, keyNode, valueNode, cachedField.Name, fieldVal)
+					fieldValidationErrs, err := unmarshalNode(ctx, modelTag+"."+key, keyNode, valueNode, cachedField.Name, fieldVal)
 					if err != nil {
 						return err
 					}

--- a/marshaller/unmarshalling_test.go
+++ b/marshaller/unmarshalling_test.go
@@ -165,7 +165,7 @@ boolField: true
 intField: 42
 float64Field: 3.14
 `,
-			wantErrs: []string{"[2:14] testPrimitiveModel expected scalar, got sequence"},
+			wantErrs: []string{"[2:14] testPrimitiveModel.stringField expected scalar, got sequence"},
 		},
 		{
 			name: "type mismatch - bool field gets string",
@@ -175,7 +175,7 @@ boolField: "not a bool"
 intField: 42
 float64Field: 3.14
 `,
-			wantErrs: []string{"[3:12] testPrimitiveModel yaml: unmarshal errors:"},
+			wantErrs: []string{"[3:12] testPrimitiveModel.boolField yaml: unmarshal errors:"},
 		},
 		{
 			name: "type mismatch - int field gets string",
@@ -185,7 +185,7 @@ boolField: true
 intField: "not an int"
 float64Field: 3.14
 `,
-			wantErrs: []string{"[4:11] testPrimitiveModel yaml: unmarshal errors:"},
+			wantErrs: []string{"[4:11] testPrimitiveModel.intField yaml: unmarshal errors:"},
 		},
 		{
 			name: "type mismatch - float field gets string",
@@ -195,7 +195,7 @@ boolField: true
 intField: 42
 float64Field: "not a float"
 `,
-			wantErrs: []string{"[5:15] testPrimitiveModel yaml: unmarshal errors:"},
+			wantErrs: []string{"[5:15] testPrimitiveModel.float64Field yaml: unmarshal errors:"},
 		},
 		{
 			name: "multiple validation errors",
@@ -206,7 +206,7 @@ intField: "not an int"
 			wantErrs: []string{
 				"[2:1] testPrimitiveModel field stringField is missing",
 				"[2:1] testPrimitiveModel field float64Field is missing",
-				"[2:12] testPrimitiveModel yaml: unmarshal errors:",
+				"[2:12] testPrimitiveModel.boolField yaml: unmarshal errors:",
 			},
 		},
 	}
@@ -379,7 +379,7 @@ nestedModelValue:
 nestedModel:
   - "this should be an object"
 `,
-			wantErrs: []string{"[8:3] testComplexModel expected object, got sequence"},
+			wantErrs: []string{"[8:3] testComplexModel.nestedModel expected object, got sequence"},
 		},
 		{
 			name: "type mismatch - array field gets object",
@@ -392,7 +392,7 @@ nestedModelValue:
 arrayField:
   key: "this should be an array"
 `,
-			wantErrs: []string{"[8:3] testComplexModel expected sequence, got object"},
+			wantErrs: []string{"[8:3] testComplexModel.arrayField expected sequence, got object"},
 		},
 		{
 			name: "deeply nested validation error",

--- a/openapi/join_test.go
+++ b/openapi/join_test.go
@@ -257,11 +257,19 @@ func TestJoin_NoFilePath_Success(t *testing.T) {
 	err = openapi.Join(ctx, mainDoc, documents, opts)
 	require.NoError(t, err)
 
-	// Verify original /users path exists
+	// Verify original /users path exists and contains both operations
 	assert.True(t, mainDoc.Paths.Has("/users"))
+	usersPath, exists := mainDoc.Paths.Get("/users")
+	require.True(t, exists, "Users path should exist")
+	require.NotNil(t, usersPath)
+	require.NotNil(t, usersPath.Object)
 
-	// Verify conflicting path uses fallback name
-	assert.True(t, mainDoc.Paths.Has("/users#document_0"))
+	// Should have both GET (from main) and POST (from second)
+	assert.NotNil(t, usersPath.Object.Get, "Should have GET operation from main document")
+	assert.NotNil(t, usersPath.Object.Post, "Should have POST operation from second document")
+
+	// Should NOT have a duplicated path since methods are different
+	assert.False(t, mainDoc.Paths.Has("/users#document_0"), "Should not create duplicate path for different methods")
 }
 
 func TestJoin_ServersSecurityConflicts_Success(t *testing.T) {

--- a/openapi/openapi_examples_test.go
+++ b/openapi/openapi_examples_test.go
@@ -214,7 +214,7 @@ func Example_validating() {
 		fmt.Println("Document is valid!")
 	}
 	// Output: Validation error: [3:3] info field version is missing
-	// Validation error: [18:30] response expected object, got scalar
+	// Validation error: [18:30] response.content expected object, got scalar
 	// Validation error: [31:25] schema field properties.name.type value must be one of 'array', 'boolean', 'integer', 'null', 'number', 'object', 'string'
 	// Validation error: [31:25] schema field properties.name.type got string, want array
 	// Additional validation error: [31:25] schema field properties.name.type value must be one of 'array', 'boolean', 'integer', 'null', 'number', 'object', 'string'

--- a/openapi/responses.go
+++ b/openapi/responses.go
@@ -105,7 +105,7 @@ func (r *Responses) Validate(ctx context.Context, opts ...validation.Option) []e
 		errs = append(errs, r.Default.Validate(ctx, opts...)...)
 	}
 
-	if r.Len() == 0 {
+	if r.Len() == 0 && r.Default == nil {
 		errs = append(errs, validation.NewValidationError(validation.NewValueValidationError("responses must have at least one response code"), core.RootNode))
 	}
 

--- a/openapi/responses_validate_test.go
+++ b/openapi/responses_validate_test.go
@@ -255,6 +255,20 @@ default:
 x-test: some-value
 `,
 		},
+		{
+			name: "valid responses with only default",
+			yml: `
+default:
+  description: Default response for all status codes
+  content:
+    application/json:
+      schema:
+        type: object
+        properties:
+          message:
+            type: string
+`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/openapi/testdata/join/joined_conflicts_expected.yaml
+++ b/openapi/testdata/join/joined_conflicts_expected.yaml
@@ -9,6 +9,7 @@ tags:
 paths:
   /users:
     get:
+      operationId: getUsers
       summary: Get users
       responses:
         '200':

--- a/openapi/testdata/join/joined_counter_expected.yaml
+++ b/openapi/testdata/join/joined_counter_expected.yaml
@@ -16,6 +16,7 @@ tags:
 paths:
   /users:
     get:
+      operationId: getUsers
       summary: Get users
       responses:
         '200':
@@ -24,6 +25,17 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/User'
+    post:
+      operationId: createUser
+      summary: Create user
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/User_1'
+      responses:
+        "201":
+          description: Created
   /health:
     get:
       summary: Health check
@@ -40,19 +52,25 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Product'
-  /users#second:
-    post:
-      summary: Create user
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/User_1'
+  /health#second:
+    get:
+      summary: Different health check
+      description: A different health check implementation
       responses:
-        "201":
-          description: Created
+        "200":
+          description: Different OK response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                  timestamp:
+                    type: string
   /orders:
     get:
+      operationId: getUsers#third
       summary: Get orders
       responses:
         "200":

--- a/openapi/testdata/join/joined_filepath_expected.yaml
+++ b/openapi/testdata/join/joined_filepath_expected.yaml
@@ -16,6 +16,7 @@ tags:
 paths:
   /users:
     get:
+      operationId: getUsers
       summary: Get users
       responses:
         '200':
@@ -24,6 +25,17 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/User'
+    post:
+      operationId: createUser
+      summary: Create user
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/subdir_second_yaml~User'
+      responses:
+        "201":
+          description: Created
   /health:
     get:
       summary: Health check
@@ -40,19 +52,25 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Product'
-  /users#second:
-    post:
-      summary: Create user
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/subdir_second_yaml~User'
+  /health#second:
+    get:
+      summary: Different health check
+      description: A different health check implementation
       responses:
-        "201":
-          description: Created
+        "200":
+          description: Different OK response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                  timestamp:
+                    type: string
   /orders:
     get:
+      operationId: getUsers#third
       summary: Get orders
       responses:
         "200":

--- a/openapi/testdata/join/main.yaml
+++ b/openapi/testdata/join/main.yaml
@@ -14,6 +14,7 @@ tags:
 paths:
   /users:
     get:
+      operationId: getUsers
       summary: Get users
       responses:
         '200':

--- a/openapi/testdata/join/subdir/second.yaml
+++ b/openapi/testdata/join/subdir/second.yaml
@@ -23,9 +23,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/Product'
   /users:
-    # This conflicts with main.yaml /users path
+    # This should merge with main.yaml /users path (different method)
     post:
       summary: Create user
+      operationId: createUser
       requestBody:
         content:
           application/json:
@@ -34,6 +35,23 @@ paths:
       responses:
         '201':
           description: Created
+  /health:
+    # This should conflict with main.yaml /health path (same method, different operation)
+    get:
+      summary: Different health check
+      description: A different health check implementation
+      responses:
+        '200':
+          description: Different OK response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                  timestamp:
+                    type: string
 webhooks:
   productUpdated:
     post:

--- a/openapi/testdata/join/third.yaml
+++ b/openapi/testdata/join/third.yaml
@@ -11,6 +11,7 @@ security:
 paths:
   /orders:
     get:
+      operationId: getUsers # This conflicts with main.yaml getUsers operationId
       summary: Get orders
       responses:
         '200':
@@ -18,7 +19,14 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Order'
+                $ref: "#/components/schemas/Order"
+  /health:
+    # This should be deduplicated with main.yaml /health path (identical operation)
+    get:
+      summary: Health check
+      responses:
+        "200":
+          description: OK
 components:
   schemas:
     Order:

--- a/references/resolution.go
+++ b/references/resolution.go
@@ -25,6 +25,7 @@ type ResolutionTarget interface {
 }
 
 type Resolvable[T any] interface {
+	GetReference() Reference
 	Resolve(ctx context.Context, opts ResolveOptions) ([]error, error)
 	GetResolvedObject() *T
 }

--- a/sequencedmap/map.go
+++ b/sequencedmap/map.go
@@ -10,7 +10,7 @@ import (
 	"iter"
 	"reflect"
 	"slices"
-	"sort"
+	"strings"
 
 	"github.com/speakeasy-api/openapi/internal/interfaces"
 	"github.com/speakeasy-api/openapi/yml"
@@ -442,8 +442,8 @@ func (m *Map[K, V]) AllOrdered(order OrderType) iter.Seq2[K, V] {
 			// Sort by key in ascending order
 			sortedElements := make([]*Element[K, V], len(snapshot))
 			copy(sortedElements, snapshot)
-			sort.Slice(sortedElements, func(i, j int) bool {
-				return compareKeys(sortedElements[i].Key, sortedElements[j].Key) < 0
+			slices.SortFunc(sortedElements, func(a, b *Element[K, V]) int {
+				return compareKeys(a.Key, b.Key)
 			})
 			for _, element := range sortedElements {
 				// Check if element still exists in the map (it might have been deleted during iteration)
@@ -458,8 +458,8 @@ func (m *Map[K, V]) AllOrdered(order OrderType) iter.Seq2[K, V] {
 			// Sort by key in descending order
 			sortedElements := make([]*Element[K, V], len(snapshot))
 			copy(sortedElements, snapshot)
-			sort.Slice(sortedElements, func(i, j int) bool {
-				return compareKeys(sortedElements[i].Key, sortedElements[j].Key) > 0
+			slices.SortFunc(sortedElements, func(a, b *Element[K, V]) int {
+				return -compareKeys(a.Key, b.Key)
 			})
 			for _, element := range sortedElements {
 				// Check if element still exists in the map (it might have been deleted during iteration)
@@ -692,17 +692,12 @@ func (m *Map[K, V]) MarshalYAML() (interface{}, error) {
 }
 
 // compareKeys provides a generic comparison function for keys
-func compareKeys[K comparable](a, b K) int {
+func compareKeys[K any](a, b K) int {
 	// Convert to strings for comparison
 	aStr := fmt.Sprintf("%v", a)
 	bStr := fmt.Sprintf("%v", b)
 
-	if aStr < bStr {
-		return -1
-	} else if aStr > bStr {
-		return 1
-	}
-	return 0
+	return strings.Compare(aStr, bStr)
 }
 
 // IsEqual compares two Map instances for equality.


### PR DESCRIPTION
## Summary

This PR addresses several critical issues in OpenAPI join functionality, conflict resolution, and validation. The changes improve the robustness of the library when handling complex OpenAPI document merging scenarios.

## Changes Made

### 🔧 OpenAPI Join Improvements
- **Enhanced conflict resolution**: Improved handling of conflicting elements during OpenAPI document joins
- **Better validation logic**: Strengthened validation for joined documents to catch edge cases
- **Expanded test coverage**: Added comprehensive test cases for various join scenarios

### 🛠️ Core Fixes
- **Sequenced map iteration**: Fixed ordered iteration issues in `sequencedmap/map.go`
- **Response validation**: Enhanced validation logic in `openapi/responses.go`
- **Reference resolution**: Improved `Resolvable` interface implementation
- **Marshalling improvements**: Fixed unmarshalling edge cases in `marshaller/unmarshaller.go`

### 📋 Test Data Updates
- Updated test expectations for join operations
- Added new test scenarios for conflict resolution
- Enhanced validation test coverage

## Files Changed
- `openapi/join.go` (+197 lines) - Major enhancements to join functionality
- `sequencedmap/map.go` - Fixed ordered iteration
- `openapi/responses.go` - Validation improvements
- `jsonschema/oas3/resolution.go` - Enhanced resolution logic
- `references/resolution.go` - Interface improvements
- Multiple test files and test data updates

## Testing
- All existing tests pass
- New test cases added for edge cases
- Comprehensive validation of join scenarios

## Breaking Changes
None - all changes are backward compatible.

## Related Issues
Addresses various edge cases in OpenAPI document joining and validation that could lead to incorrect behavior in complex scenarios.