### PR TITLE
ci: add workflow to auto-update cmd/openapi dependency

### DIFF
--- a/.github/workflows/update-cmd-dependency.yaml
+++ b/.github/workflows/update-cmd-dependency.yaml
@@ -1,0 +1,89 @@
+name: Update CMD OpenAPI Dependency
+
+on:
+    push:
+        branches: [main]
+        # Only run if changes affect the root module (not cmd/openapi itself)
+        paths-ignore:
+            - "cmd/openapi/**"
+            - ".github/workflows/update-cmd-dependency.yaml"
+
+permissions:
+    contents: write
+    pull-requests: write
+
+jobs:
+    update-dependency:
+        name: Update cmd/openapi dependency
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6
+
+            - name: Setup Go
+              uses: actions/setup-go@v6
+              with:
+                  go-version-file: "go.mod"
+                  cache: false # Disable caching to ensure fresh dependency resolution
+
+            - name: Update cmd/openapi go.mod
+              run: |
+                  cd cmd/openapi
+
+                  # Update to latest main commit
+                  go get github.com/speakeasy-api/openapi@main
+                  go mod tidy
+
+            - name: Check for changes
+              id: changes
+              run: |
+                  if git diff --quiet cmd/openapi/go.mod cmd/openapi/go.sum; then
+                    echo "changed=false" >> $GITHUB_OUTPUT
+                    echo "No changes detected in cmd/openapi/go.mod or go.sum"
+                  else
+                    echo "changed=true" >> $GITHUB_OUTPUT
+                    echo "Changes detected in cmd/openapi/go.mod or go.sum"
+                    
+                    # Get the new version for the PR description
+                    NEW_VERSION=$(grep 'github.com/speakeasy-api/openapi v' cmd/openapi/go.mod | head -1 | awk '{print $2}')
+                    echo "version=${NEW_VERSION}" >> $GITHUB_OUTPUT
+                    echo "Updated to version: ${NEW_VERSION}"
+                  fi
+
+            - name: Create Pull Request
+              if: steps.changes.outputs.changed == 'true'
+              uses: peter-evans/create-pull-request@v7
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}
+                  commit-message: |
+                      chore(cmd): update openapi dependency to latest main
+
+                      Updates cmd/openapi/go.mod to use the latest commit from main.
+                      Version: ${{ steps.changes.outputs.version }}
+                  branch: bot/update-cmd-openapi-dependency
+                  delete-branch: true
+                  title: "chore(cmd): update openapi dependency to latest main"
+                  body: |
+                      ## Updates cmd/openapi dependency
+
+                      This PR updates the `cmd/openapi/go.mod` file to reference the latest commit from main.
+
+                      **Updated to:** `${{ steps.changes.outputs.version }}`
+
+                      **Changes:**
+                      - Updated `github.com/speakeasy-api/openapi` dependency in `cmd/openapi/go.mod`
+                      - Ran `go mod tidy` to update dependencies
+
+                      ---
+                      *This PR was automatically created by the [update-cmd-dependency workflow](.github/workflows/update-cmd-dependency.yaml)*
+                  labels: |
+                      dependencies
+                      automated
+
+            - name: Summary
+              run: |
+                  if [ "${{ steps.changes.outputs.changed }}" == "true" ]; then
+                    echo "✅ Pull request created to update cmd/openapi dependency"
+                    echo "Version: ${{ steps.changes.outputs.version }}"
+                  else
+                    echo "ℹ️ No changes needed - cmd/openapi dependency already up to date"
+                  fi


### PR DESCRIPTION
## Description

Adds a GitHub Action workflow that automatically updates the `cmd/openapi/go.mod` dependency to reference the latest commit from `main` whenever changes are merged.

## Problem

The `cmd/openapi` module depends on the root `github.com/speakeasy-api/openapi` module. When changes are merged to `main`, `cmd/openapi` needs to be manually updated to use the latest version. This creates friction and can lead to the CLI falling out of sync with the latest library changes.

## Solution

This PR introduces a new workflow (`.github/workflows/update-cmd-dependency.yaml`) that:

1. **Triggers** automatically on pushes to `main` (excluding changes to `cmd/openapi/**` to prevent infinite loops)
2. **Updates** the dependency using `go get github.com/speakeasy-api/openapi@main` which automatically resolves to the latest commit's pseudo-version
3. **Detects** if any changes were made to `go.mod` or `go.sum`
4. **Creates** a pull request automatically with the updated dependency if changes are detected
5. **Labels** the PR appropriately (`dependencies`, `automated`)

## Benefits

- **Automation**: Eliminates manual dependency updates
- **Consistency**: Ensures `cmd/openapi` stays up-to-date with the latest library changes
- **Transparency**: All updates go through PRs for review
- **Simple**: Leverages Go's built-in `@main` branch resolution

## Implementation Details

- Uses `go get github.com/speakeasy-api/openapi@main` which automatically creates the correct pseudo-version
- Only triggers when the root module changes (not when `cmd/openapi` itself changes)
- Uses the `peter-evans/create-pull-request` action for reliable PR creation
- Includes proper change detection to avoid unnecessary PRs

## Testing

- CI passes successfully ✅
- Workflow structure follows existing patterns in the repo
- Path exclusions prevent infinite loops