### PR TITLE
fix: convert YAML numbers with leading zeros to JSON strings

### DIFF
--- a/json/json_test.go
+++ b/json/json_test.go
@@ -228,6 +228,53 @@ upperCaseBool: FALSE
 `,
 			indentation: 2,
 		},
+		{
+			name:      "integer with leading zeros",
+			yamlInput: `bankCode: 009911`,
+			expectedJSON: `{
+  "bankCode": "009911"
+}
+`,
+			indentation: 2,
+		},
+		{
+			name: "multiple integers with leading zeros",
+			yamlInput: `identifiers:
+  bankCode: 009911
+  sortCode: 001234`,
+			expectedJSON: `{
+  "identifiers": {
+    "bankCode": "009911",
+    "sortCode": "001234"
+  }
+}
+`,
+			indentation: 2,
+		},
+		{
+			name:      "integers with leading zeros in array",
+			yamlInput: `codes: [009911, 001234, 005678]`,
+			expectedJSON: `{
+  "codes": ["009911", "001234", "005678"]
+}
+`,
+			indentation: 2,
+		},
+		{
+			name:      "octal-like integer value",
+			yamlInput: `value: 0777`,
+			expectedJSON: `{
+  "value": "0777"
+}
+`,
+			indentation: 2,
+		},
+		{
+			name:         "quoted string with leading zeros preserved",
+			yamlInput:    `bankCode: "009911"`,
+			expectedJSON: `{"bankCode":"009911"}` + "\n",
+			indentation:  0,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Fixes YAML to JSON conversion for numeric values with leading zeros (e.g., `bankCode: 009911`).

## Problem

YAML values like `009911` were being converted directly to JSON, producing invalid JSON since numbers cannot have leading zeros. This caused JSON schema validation to fail with:
```
schema is not valid json: invalid character '0' after object key:value pair
```

## Solution

Added detection for invalid JSON number formats in `json/json.go`:
- Numbers with leading zeros (e.g., `009911`, `0777`)
- Handles both `cat /tmp/pr-yaml-json-leading-zeros.mdint` and `cat /tmp/pr-yaml-json-leading-zeros.mdfloat` YAML tags
- Converts invalid numbers to quoted strings in JSON

## Testing

- Added test cases for various leading zero scenarios
- Verified fix works with the originally failing OpenAPI document
- All CI checks pass
