### PR TITLE
feat: upgrade yaml library from gopkg.in/yaml.v3 to go.yaml.in/yaml/v4

### DIFF
--- a/arazzo/arazzo_order_test.go
+++ b/arazzo/arazzo_order_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/speakeasy-api/openapi/expression"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func TestArazzo_ArrayOrdering_ReorderWorkflows_Success(t *testing.T) {

--- a/arazzo/arazzo_test.go
+++ b/arazzo/arazzo_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/speakeasy-api/openapi/yml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // TODO make it possible to choose json or yaml output

--- a/arazzo/core/criterion.go
+++ b/arazzo/core/criterion.go
@@ -11,7 +11,7 @@ import (
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/speakeasy-api/openapi/validation"
 	"github.com/speakeasy-api/openapi/yml"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 type CriterionExpressionType struct {

--- a/arazzo/core/criterion_syncchanges_test.go
+++ b/arazzo/core/criterion_syncchanges_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/speakeasy-api/openapi/pointer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func TestCriterionTypeUnion_SyncChanges_WithStringType_Success(t *testing.T) {

--- a/arazzo/core/criterion_test.go
+++ b/arazzo/core/criterion_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/speakeasy-api/openapi/pointer"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func createCriterionWithRootNode(c Criterion, rootNode *yaml.Node) Criterion {

--- a/arazzo/core/reusable.go
+++ b/arazzo/core/reusable.go
@@ -11,7 +11,7 @@ import (
 	"github.com/speakeasy-api/openapi/validation"
 	values "github.com/speakeasy-api/openapi/values/core"
 	"github.com/speakeasy-api/openapi/yml"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 type Reusable[T marshaller.CoreModeler] struct {

--- a/arazzo/core/reusable_test.go
+++ b/arazzo/core/reusable_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func TestReusable_Unmarshal_WithReference_Success(t *testing.T) {

--- a/arazzo/criterion/condition.go
+++ b/arazzo/criterion/condition.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/speakeasy-api/openapi/expression"
 	"github.com/speakeasy-api/openapi/validation"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // Operator represents the operator used to compare the value of a criterion.

--- a/arazzo/requestbody_test.go
+++ b/arazzo/requestbody_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/speakeasy-api/openapi/pointer"
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func TestRequestBody_Validate_JSONPathInPayload_Success(t *testing.T) {

--- a/arazzo/reusable.go
+++ b/arazzo/reusable.go
@@ -15,7 +15,7 @@ import (
 	"github.com/speakeasy-api/openapi/sequencedmap"
 	"github.com/speakeasy-api/openapi/validation"
 	"github.com/speakeasy-api/openapi/values"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 type (

--- a/arazzo/successaction.go
+++ b/arazzo/successaction.go
@@ -15,7 +15,7 @@ import (
 	"github.com/speakeasy-api/openapi/pointer"
 	"github.com/speakeasy-api/openapi/validation"
 	walkpkg "github.com/speakeasy-api/openapi/walk"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // SuccessActionType represents the type of action to take on success.

--- a/cmd/openapi/commands/openapi/bootstrap.go
+++ b/cmd/openapi/commands/openapi/bootstrap.go
@@ -8,7 +8,7 @@ import (
 	"github.com/speakeasy-api/openapi/openapi"
 	"github.com/speakeasy-api/openapi/yml"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 var bootstrapCmd = &cobra.Command{

--- a/cmd/openapi/commands/overlay/apply.go
+++ b/cmd/openapi/commands/overlay/apply.go
@@ -8,7 +8,7 @@ import (
 	overlayPkg "github.com/speakeasy-api/openapi/overlay"
 	"github.com/speakeasy-api/openapi/overlay/loader"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 var (

--- a/cmd/openapi/commands/overlay/compare.go
+++ b/cmd/openapi/commands/overlay/compare.go
@@ -8,7 +8,7 @@ import (
 	overlayPkg "github.com/speakeasy-api/openapi/overlay"
 	"github.com/speakeasy-api/openapi/overlay/loader"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 var (

--- a/cmd/openapi/go.mod
+++ b/cmd/openapi/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260217225223-7d484a30828f
 	github.com/spf13/cobra v1.10.1
 	github.com/stretchr/testify v1.11.1
-	gopkg.in/yaml.v3 v3.0.1
+	go.yaml.in/yaml/v4 v4.0.0-rc.4
 )
 
 require (
@@ -46,4 +46,5 @@ require (
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.36.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/cmd/openapi/go.sum
+++ b/cmd/openapi/go.sum
@@ -101,6 +101,8 @@ github.com/vmware-labs/yaml-jsonpath v0.3.2 h1:/5QKeCBGdsInyDCyVNLbXyilb61MXGi9N
 github.com/vmware-labs/yaml-jsonpath v0.3.2/go.mod h1:U6whw1z03QyqgWdgXxvVnQ90zN1BWz5V+51Ewf8k+rQ=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
+go.yaml.in/yaml/v4 v4.0.0-rc.4 h1:UP4+v6fFrBIb1l934bDl//mmnoIZEDK0idg1+AIvX5U=
+go.yaml.in/yaml/v4 v4.0.0-rc.4/go.mod h1:aZqd9kCMsGL7AuUv/m/PvWLdg5sjJsZ4oHDEnfPPfY0=
 golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561 h1:MDc5xs78ZrZr3HMQugiXOAkSZtfTpbJLDr/lwfgO53E=
 golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/expression/core/value.go
+++ b/expression/core/value.go
@@ -1,5 +1,5 @@
 package core
 
-import "gopkg.in/yaml.v3"
+import "go.yaml.in/yaml/v4"
 
 type ValueOrExpression = *yaml.Node

--- a/expression/value.go
+++ b/expression/value.go
@@ -1,7 +1,7 @@
 package expression
 
 import (
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // ValueOrExpression represents a raw value or expression in the Arazzo document.

--- a/expression/value_test.go
+++ b/expression/value_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/speakeasy-api/openapi/expression"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func TestGetValueOrExpressionValue_Success(t *testing.T) {

--- a/extensions/core/extensions.go
+++ b/extensions/core/extensions.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/speakeasy-api/openapi/sequencedmap"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 type (

--- a/extensions/core/extensions_test.go
+++ b/extensions/core/extensions_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/speakeasy-api/openapi/sequencedmap"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 type TestCoreModel struct {

--- a/extensions/extensions.go
+++ b/extensions/extensions.go
@@ -10,7 +10,7 @@ import (
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/speakeasy-api/openapi/sequencedmap"
 	"github.com/speakeasy-api/openapi/yml"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 const (

--- a/extensions/extensions_isequal_test.go
+++ b/extensions/extensions_isequal_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func TestExtensions_IsEqual_Success(t *testing.T) {

--- a/extensions/extensions_test.go
+++ b/extensions/extensions_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/speakeasy-api/openapi/sequencedmap"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 type ModelWithExtensions struct {

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/speakeasy-api/jsonpath v0.6.3
 	github.com/stretchr/testify v1.11.1
 	github.com/vmware-labs/yaml-jsonpath v0.3.2
+	go.yaml.in/yaml/v4 v4.0.0-rc.4
 	golang.org/x/sync v0.19.0
 	golang.org/x/text v0.34.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/vmware-labs/yaml-jsonpath v0.3.2 h1:/5QKeCBGdsInyDCyVNLbXyilb61MXGi9NP674f9Hobk=
 github.com/vmware-labs/yaml-jsonpath v0.3.2/go.mod h1:U6whw1z03QyqgWdgXxvVnQ90zN1BWz5V+51Ewf8k+rQ=
+go.yaml.in/yaml/v4 v4.0.0-rc.4 h1:UP4+v6fFrBIb1l934bDl//mmnoIZEDK0idg1+AIvX5U=
+go.yaml.in/yaml/v4 v4.0.0-rc.4/go.mod h1:aZqd9kCMsGL7AuUv/m/PvWLdg5sjJsZ4oHDEnfPPfY0=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.42.0 h1:jzkYrhi3YQWD6MLBJcsklgQsoAcw89EcZbJw8Z614hs=
 golang.org/x/net v0.42.0/go.mod h1:FF1RA5d3u7nAYA4z2TkclSCKh68eSXtiFwcWQpPXdt8=

--- a/hashing/hashing.go
+++ b/hashing/hashing.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/speakeasy-api/openapi/internal/interfaces"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func Hash(v any) string {

--- a/hashing/hashing_test.go
+++ b/hashing/hashing_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/speakeasy-api/openapi/yml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 type testEnum string

--- a/internal/interfaces/interfaces.go
+++ b/internal/interfaces/interfaces.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 
 	"github.com/speakeasy-api/openapi/validation"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 type Validator[T any] interface {

--- a/internal/interfaces/interfaces_test.go
+++ b/internal/interfaces/interfaces_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/speakeasy-api/openapi/validation"
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // Test implementations for Model interface

--- a/internal/testutils/utils.go
+++ b/internal/testutils/utils.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/speakeasy-api/openapi/yml"
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // TODO use these more in tests

--- a/internal/testutils/utils.go
+++ b/internal/testutils/utils.go
@@ -12,10 +12,13 @@ import (
 	"reflect"
 	"strconv"
 	"testing"
+	"unsafe"
 
+	"github.com/speakeasy-api/jsonpath/pkg/jsonpath"
 	"github.com/speakeasy-api/openapi/yml"
 	"github.com/stretchr/testify/assert"
 	"go.yaml.in/yaml/v4"
+	yamlv3 "gopkg.in/yaml.v3"
 )
 
 // TODO use these more in tests
@@ -182,4 +185,12 @@ func DownloadFile(url, cacheEnvVar, cacheDirName string) (io.ReadCloser, error) 
 
 	// Return the data as a ReadCloser
 	return io.NopCloser(bytes.NewReader(data)), nil
+}
+
+// QueryV4 runs a jsonpath query using a v4 node by casting to v3 and back.
+// This bridges the gap between jsonpath libraries that use yaml.v3 types and
+// the v4 types used throughout this codebase.
+func QueryV4(path *jsonpath.JSONPath, node *yaml.Node) []*yaml.Node {
+	v3result := path.Query((*yamlv3.Node)(unsafe.Pointer(node))) //nolint:gosec // v4.Node is a strict superset of v3.Node (verified at init)
+	return *(*[]*yaml.Node)(unsafe.Pointer(&v3result))           //nolint:gosec // pointer types have identical memory layouts
 }

--- a/internal/testutils/utils_test.go
+++ b/internal/testutils/utils_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func TestCreateStringYamlNode_Success(t *testing.T) {

--- a/json/json.go
+++ b/json/json.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/speakeasy-api/openapi/yml"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // YAMLToJSON converts a YAML node to JSON using a custom JSON writer that preserves formatting.

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/speakeasy-api/openapi/json"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func TestYAMLToJSON_Success(t *testing.T) {

--- a/jsonpointer/jsonpointer.go
+++ b/jsonpointer/jsonpointer.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/speakeasy-api/openapi/errors"
 	"github.com/speakeasy-api/openapi/internal/interfaces"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 const (

--- a/jsonpointer/models_yaml_fallback_test.go
+++ b/jsonpointer/models_yaml_fallback_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // TestModel represents a simple model for testing YAML fallback
@@ -39,7 +39,7 @@ knownField: "known value"
 unknownField: "unknown value"
 `,
 			jsonPointer:  "/unknownField",
-			expectedType: "*yaml.Node",
+			expectedType: "*libyaml.Node",
 			expectedVal:  "unknown value",
 		},
 		{
@@ -50,7 +50,7 @@ unknownObject:
   nestedField: "nested value"
 `,
 			jsonPointer:  "/unknownObject/nestedField",
-			expectedType: "*yaml.Node",
+			expectedType: "*libyaml.Node",
 			expectedVal:  "nested value",
 		},
 		{
@@ -62,7 +62,7 @@ unknownArray:
   - "item2"
 `,
 			jsonPointer:  "/unknownArray/1",
-			expectedType: "*yaml.Node",
+			expectedType: "*libyaml.Node",
 			expectedVal:  "item2",
 		},
 	}

--- a/jsonpointer/yamlnode.go
+++ b/jsonpointer/yamlnode.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func getYamlNodeTarget(node *yaml.Node, currentPart navigationPart, stack []navigationPart, currentPath string, o *options) (any, []navigationPart, error) {

--- a/jsonpointer/yamlnode_test.go
+++ b/jsonpointer/yamlnode_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func TestGetTarget_YamlNode_Success(t *testing.T) {

--- a/jsonschema/oas3/core/jsonschema_test.go
+++ b/jsonschema/oas3/core/jsonschema_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func TestJSONSchema_Unmarshal_BooleanValue_Success(t *testing.T) {

--- a/jsonschema/oas3/core/xml_test.go
+++ b/jsonschema/oas3/core/xml_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func parseYAML(t *testing.T, yml string) *yaml.Node {

--- a/jsonschema/oas3/jsonschema_validate_test.go
+++ b/jsonschema/oas3/jsonschema_validate_test.go
@@ -227,7 +227,7 @@ func TestJSONSchema_Validate_Error(t *testing.T) {
 			name: "schema fails direct validation",
 			yml: `
 "test"`,
-			wantErrs: []string{"[2:1] error validation-type-mismatch failed to validate either Schema [expected `object`, got `te...`] or bool [line 2: cannot unmarshal !!str `test` into bool]"},
+			wantErrs: []string{"[2:1] error validation-type-mismatch failed to validate either Schema [expected `object`, got `te...`] or bool [line 2: cannot construct !!str `test` into bool]"},
 		},
 		{
 			name: "child schema fails validation",

--- a/jsonschema/oas3/resolution.go
+++ b/jsonschema/oas3/resolution.go
@@ -9,7 +9,7 @@ import (
 	"github.com/speakeasy-api/openapi/internal/utils"
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/speakeasy-api/openapi/references"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // ResolveOptions represent the options available when resolving a JSON Schema reference.

--- a/jsonschema/oas3/resolution_defs.go
+++ b/jsonschema/oas3/resolution_defs.go
@@ -8,7 +8,7 @@ import (
 	"github.com/speakeasy-api/openapi/internal/utils"
 	"github.com/speakeasy-api/openapi/jsonpointer"
 	"github.com/speakeasy-api/openapi/references"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // GetRootNoder is an interface for objects that can return a YAML root node.

--- a/jsonschema/oas3/resolution_defs_test.go
+++ b/jsonschema/oas3/resolution_defs_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/speakeasy-api/openapi/references"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func TestTryResolveLocalDefs_NilAndBooleanSchema(t *testing.T) {

--- a/jsonschema/oas3/resolution_external.go
+++ b/jsonschema/oas3/resolution_external.go
@@ -9,7 +9,7 @@ import (
 	"github.com/speakeasy-api/openapi/jsonpointer"
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/speakeasy-api/openapi/references"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // resolveExternalAnchorReference handles resolution of anchor references (e.g., "file.json#anchor")

--- a/jsonschema/oas3/resolution_external_test.go
+++ b/jsonschema/oas3/resolution_external_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func TestResolveExternalAnchorReference_Success(t *testing.T) {

--- a/jsonschema/oas3/resolution_test.go
+++ b/jsonschema/oas3/resolution_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/speakeasy-api/openapi/references"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // MockResolutionTarget implements references.ResolutionTarget for testing

--- a/jsonschema/oas3/schema_exclusive_validation_test.go
+++ b/jsonschema/oas3/schema_exclusive_validation_test.go
@@ -248,7 +248,7 @@ exclusiveMaximum: false
 type: number
 exclusiveMinimum: "invalid"
 `,
-			wantErrs: []string{"[2:1] error validation-type-mismatch schema.exclusiveMinimum expected `number`, got `string`", "[3:19] error validation-type-mismatch schema.exclusiveMinimum failed to validate either bool [schema.exclusiveMinimum line 3: cannot unmarshal !!str `invalid` into bool] or float64 [schema.exclusiveMinimum line 3: cannot unmarshal !!str `invalid` into float64]"},
+			wantErrs: []string{"[2:1] error validation-type-mismatch schema.exclusiveMinimum expected `number`, got `string`", "[3:19] error validation-type-mismatch schema.exclusiveMinimum failed to validate either bool [schema.exclusiveMinimum line 3: cannot construct !!str `invalid` into bool] or float64 [schema.exclusiveMinimum line 3: cannot construct !!str `invalid` into float64]"},
 		},
 		{
 			name: "invalid string type for exclusiveMaximum",
@@ -256,7 +256,7 @@ exclusiveMinimum: "invalid"
 type: number
 exclusiveMaximum: "invalid"
 `,
-			wantErrs: []string{"[2:1] error validation-type-mismatch schema.exclusiveMaximum expected `number`, got `string`", "[3:19] error validation-type-mismatch schema.exclusiveMaximum failed to validate either bool [schema.exclusiveMaximum line 3: cannot unmarshal !!str `invalid` into bool] or float64 [schema.exclusiveMaximum line 3: cannot unmarshal !!str `invalid` into float64]"},
+			wantErrs: []string{"[2:1] error validation-type-mismatch schema.exclusiveMaximum expected `number`, got `string`", "[3:19] error validation-type-mismatch schema.exclusiveMaximum failed to validate either bool [schema.exclusiveMaximum line 3: cannot construct !!str `invalid` into bool] or float64 [schema.exclusiveMaximum line 3: cannot construct !!str `invalid` into float64]"},
 		},
 		{
 			name: "invalid array type for exclusiveMinimum",

--- a/jsonschema/oas3/schema_getters_test.go
+++ b/jsonschema/oas3/schema_getters_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/speakeasy-api/openapi/sequencedmap"
 	"github.com/speakeasy-api/openapi/values"
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func TestSchema_GetExclusiveMaximum_Success(t *testing.T) {

--- a/jsonschema/oas3/schema_isequal_test.go
+++ b/jsonschema/oas3/schema_isequal_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/speakeasy-api/openapi/sequencedmap"
 	"github.com/speakeasy-api/openapi/values"
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func TestSchema_IsEqual_Success(t *testing.T) {

--- a/jsonschema/oas3/schema_validate_test.go
+++ b/jsonschema/oas3/schema_validate_test.go
@@ -427,7 +427,7 @@ additionalProperties: "invalid"
 			wantErrs: []string{
 				"[2:1] error validation-type-mismatch schema.additionalProperties expected one of [`boolean`, `object`], got `string`",
 				"[2:1] error validation-type-mismatch schema.additionalProperties expected one of [`boolean`, `object`], got `string`",
-				"[3:23] error validation-type-mismatch schema.additionalProperties failed to validate either Schema [schema.additionalProperties expected `object`, got `invalid`] or bool [schema.additionalProperties line 3: cannot unmarshal !!str `invalid` into bool]",
+				"[3:23] error validation-type-mismatch schema.additionalProperties failed to validate either Schema [schema.additionalProperties expected `object`, got `invalid`] or bool [schema.additionalProperties line 3: cannot construct !!str `invalid` into bool]",
 			},
 		},
 		{
@@ -455,7 +455,7 @@ items: "invalid"
 			wantErrs: []string{
 				"[2:1] error validation-type-mismatch schema.items expected one of [`boolean`, `object`], got `string`",
 				"[2:1] error validation-type-mismatch schema.items expected one of [`boolean`, `object`], got `string`",
-				"[3:8] error validation-type-mismatch schema.items failed to validate either Schema [schema.items expected `object`, got `invalid`] or bool [schema.items line 3: cannot unmarshal !!str `invalid` into bool]",
+				"[3:8] error validation-type-mismatch schema.items failed to validate either Schema [schema.items expected `object`, got `invalid`] or bool [schema.items line 3: cannot construct !!str `invalid` into bool]",
 			},
 		},
 		{

--- a/jsonschema/oas3/tests/go.mod
+++ b/jsonschema/oas3/tests/go.mod
@@ -60,6 +60,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.37.0 // indirect
 	go.opentelemetry.io/otel/trace v1.37.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.7.1 // indirect
+	go.yaml.in/yaml/v4 v4.0.0-rc.4 // indirect
 	golang.org/x/crypto v0.45.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.38.0 // indirect

--- a/jsonschema/oas3/tests/go.sum
+++ b/jsonschema/oas3/tests/go.sum
@@ -133,6 +133,8 @@ go.opentelemetry.io/otel/trace v1.37.0 h1:HLdcFNbRQBE2imdSEgm/kwqmQj1Or1l/7bW6mx
 go.opentelemetry.io/otel/trace v1.37.0/go.mod h1:TlgrlQ+PtQO5XFerSPUYG0JSgGyryXewPGyayAWSBS0=
 go.opentelemetry.io/proto/otlp v1.7.1 h1:gTOMpGDb0WTBOP8JaO72iL3auEZhVmAQg4ipjOVAtj4=
 go.opentelemetry.io/proto/otlp v1.7.1/go.mod h1:b2rVh6rfI/s2pHWNlB7ILJcRALpcNDzKhACevjI+ZnE=
+go.yaml.in/yaml/v4 v4.0.0-rc.4 h1:UP4+v6fFrBIb1l934bDl//mmnoIZEDK0idg1+AIvX5U=
+go.yaml.in/yaml/v4 v4.0.0-rc.4/go.mod h1:aZqd9kCMsGL7AuUv/m/PvWLdg5sjJsZ4oHDEnfPPfY0=
 golang.org/x/crypto v0.45.0 h1:jMBrvKuj23MTlT0bQEOBcAE0mjg8mK9RXFhRH6nyF3Q=
 golang.org/x/crypto v0.45.0/go.mod h1:XTGrrkGJve7CYK7J8PEww4aY7gM3qMCElcJQ8n8JdX4=
 golang.org/x/net v0.47.0 h1:Mx+4dIFzqraBXUugkia1OOvlD6LemFo1ALMHjrXDOhY=

--- a/jsonschema/oas3/validation.go
+++ b/jsonschema/oas3/validation.go
@@ -17,9 +17,9 @@ import (
 	"github.com/speakeasy-api/openapi/jsonschema/oas3/core"
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/speakeasy-api/openapi/validation"
+	"go.yaml.in/yaml/v4"
 	"golang.org/x/text/language"
 	"golang.org/x/text/message"
-	"gopkg.in/yaml.v3"
 )
 
 // custom file to cover for missing openapi 3.0 json schema

--- a/linter/config.go
+++ b/linter/config.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/speakeasy-api/openapi/references"
 	"github.com/speakeasy-api/openapi/validation"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // Config represents the linter configuration

--- a/linter/config_loader.go
+++ b/linter/config_loader.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"os"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // LoadConfig loads lint configuration from a YAML reader.

--- a/linter/fix/engine.go
+++ b/linter/fix/engine.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/speakeasy-api/openapi/openapi"
 	"github.com/speakeasy-api/openapi/validation"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // Mode controls how fixes are applied.

--- a/linter/fix/engine_test.go
+++ b/linter/fix/engine_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/speakeasy-api/openapi/validation"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // mockFix is a non-interactive fix for testing.

--- a/linter/fix/terminal_prompter_test.go
+++ b/linter/fix/terminal_prompter_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/speakeasy-api/openapi/validation"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func TestTerminalPrompter_Choice_Success(t *testing.T) {

--- a/linter/format/format_test.go
+++ b/linter/format/format_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/speakeasy-api/openapi/validation"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // testFix is a minimal validation.Fix for testing formatter output.

--- a/marshaller/coremodel.go
+++ b/marshaller/coremodel.go
@@ -11,7 +11,7 @@ import (
 	"github.com/speakeasy-api/openapi/json"
 	"github.com/speakeasy-api/openapi/validation"
 	"github.com/speakeasy-api/openapi/yml"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 type CoreModeler interface {

--- a/marshaller/coremodel_getters_test.go
+++ b/marshaller/coremodel_getters_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func TestCoreModel_GetRootNodeLine_Success(t *testing.T) {

--- a/marshaller/coremodel_jsonpath_test.go
+++ b/marshaller/coremodel_jsonpath_test.go
@@ -2,13 +2,21 @@ package marshaller_test
 
 import (
 	"testing"
+	"unsafe"
 
 	"github.com/speakeasy-api/jsonpath/pkg/jsonpath"
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
+	yamlv3 "gopkg.in/yaml.v3"
 )
+
+// queryV4 runs a jsonpath query using a v4 node by casting to v3 and back.
+func queryV4(path *jsonpath.JSONPath, node *yaml.Node) []*yaml.Node {
+	v3result := path.Query((*yamlv3.Node)(unsafe.Pointer(node)))
+	return *(*[]*yaml.Node)(unsafe.Pointer(&v3result))
+}
 
 func TestCoreModel_GetJSONPath_Success(t *testing.T) {
 	t.Parallel()
@@ -178,7 +186,7 @@ func findNodeByJSONPath(t *testing.T, rootNode *yaml.Node, jsonPath string) *yam
 	require.NoError(t, err, "JSONPath should be valid: %s", jsonPath)
 
 	// Query the YAML node directly
-	result := path.Query(rootNode)
+	result := queryV4(path, rootNode)
 	require.NotEmpty(t, result, "JSONPath query should return results: %s", jsonPath)
 
 	// The result should be a slice of *yaml.Node, so return the first one
@@ -196,7 +204,7 @@ func verifyJSONPathWorks(t *testing.T, rootNode *yaml.Node, jsonPath string, exp
 	path, err := jsonpath.NewPath(jsonPath)
 	require.NoError(t, err, "generated JSONPath should be valid: %s", jsonPath)
 
-	result := path.Query(rootNode)
+	result := queryV4(path, rootNode)
 	require.NotEmpty(t, result, "JSONPath query should return results: %s", jsonPath)
 
 	// Special case for root node: the query might return the document node

--- a/marshaller/coremodel_jsonpath_test.go
+++ b/marshaller/coremodel_jsonpath_test.go
@@ -2,21 +2,14 @@ package marshaller_test
 
 import (
 	"testing"
-	"unsafe"
 
 	"github.com/speakeasy-api/jsonpath/pkg/jsonpath"
+	"github.com/speakeasy-api/openapi/internal/testutils"
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.yaml.in/yaml/v4"
-	yamlv3 "gopkg.in/yaml.v3"
 )
-
-// queryV4 runs a jsonpath query using a v4 node by casting to v3 and back.
-func queryV4(path *jsonpath.JSONPath, node *yaml.Node) []*yaml.Node {
-	v3result := path.Query((*yamlv3.Node)(unsafe.Pointer(node)))
-	return *(*[]*yaml.Node)(unsafe.Pointer(&v3result))
-}
 
 func TestCoreModel_GetJSONPath_Success(t *testing.T) {
 	t.Parallel()
@@ -186,7 +179,7 @@ func findNodeByJSONPath(t *testing.T, rootNode *yaml.Node, jsonPath string) *yam
 	require.NoError(t, err, "JSONPath should be valid: %s", jsonPath)
 
 	// Query the YAML node directly
-	result := queryV4(path, rootNode)
+	result := testutils.QueryV4(path, rootNode)
 	require.NotEmpty(t, result, "JSONPath query should return results: %s", jsonPath)
 
 	// The result should be a slice of *yaml.Node, so return the first one
@@ -204,7 +197,7 @@ func verifyJSONPathWorks(t *testing.T, rootNode *yaml.Node, jsonPath string, exp
 	path, err := jsonpath.NewPath(jsonPath)
 	require.NoError(t, err, "generated JSONPath should be valid: %s", jsonPath)
 
-	result := queryV4(path, rootNode)
+	result := testutils.QueryV4(path, rootNode)
 	require.NotEmpty(t, result, "JSONPath query should return results: %s", jsonPath)
 
 	// Special case for root node: the query might return the document node

--- a/marshaller/coremodel_jsonpointer_test.go
+++ b/marshaller/coremodel_jsonpointer_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func TestCoreModel_GetJSONPointer_Success(t *testing.T) {

--- a/marshaller/extensions.go
+++ b/marshaller/extensions.go
@@ -9,7 +9,7 @@ import (
 	"unsafe"
 
 	"github.com/speakeasy-api/openapi/yml"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 type Extension = *yaml.Node

--- a/marshaller/factory.go
+++ b/marshaller/factory.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 
 	"github.com/speakeasy-api/openapi/sequencedmap"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // TypeFactory represents a function that creates a new instance of a specific type

--- a/marshaller/marshal.go
+++ b/marshaller/marshal.go
@@ -6,7 +6,7 @@ import (
 	"io"
 
 	"github.com/speakeasy-api/openapi/yml"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // Marshallable represents a high-level model that can be marshaled

--- a/marshaller/model.go
+++ b/marshaller/model.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"sync"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // CoreAccessor provides type-safe access to the core field in models

--- a/marshaller/model_test.go
+++ b/marshaller/model_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/speakeasy-api/openapi/marshaller/tests/core"
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // TestModel_GetPropertyNode_Success tests the GetPropertyNode method with valid inputs

--- a/marshaller/node.go
+++ b/marshaller/node.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 
 	"github.com/speakeasy-api/openapi/yml"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 type NodeMutator interface {

--- a/marshaller/node_test.go
+++ b/marshaller/node_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 type testCase[T any] struct {

--- a/marshaller/nodecollector.go
+++ b/marshaller/nodecollector.go
@@ -3,7 +3,7 @@ package marshaller
 import (
 	"reflect"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // NodeCollector provides utilities for collecting yaml.Node pointers from core models.

--- a/marshaller/nodecollector_test.go
+++ b/marshaller/nodecollector_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // Test models to verify CollectLeafNodes behavior

--- a/marshaller/populator.go
+++ b/marshaller/populator.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 
 	"github.com/speakeasy-api/openapi/internal/interfaces"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // Pre-computed reflection types for performance

--- a/marshaller/populator_unmarshalextensionmodel_test.go
+++ b/marshaller/populator_unmarshalextensionmodel_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/speakeasy-api/openapi/sequencedmap"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func init() {

--- a/marshaller/sequencedmap.go
+++ b/marshaller/sequencedmap.go
@@ -12,8 +12,8 @@ import (
 	"github.com/speakeasy-api/openapi/internal/utils"
 	"github.com/speakeasy-api/openapi/validation"
 	"github.com/speakeasy-api/openapi/yml"
+	"go.yaml.in/yaml/v4"
 	"golang.org/x/sync/errgroup"
-	"gopkg.in/yaml.v3"
 )
 
 // MapGetter interface for syncing operations

--- a/marshaller/sequencedmap_test.go
+++ b/marshaller/sequencedmap_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/speakeasy-api/openapi/sequencedmap"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // SequencedMap test case for successful operations

--- a/marshaller/syncer.go
+++ b/marshaller/syncer.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/speakeasy-api/openapi/internal/interfaces"
 	"github.com/speakeasy-api/openapi/yml"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 type Syncer interface {

--- a/marshaller/syncing_test.go
+++ b/marshaller/syncing_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/speakeasy-api/openapi/sequencedmap"
 	"github.com/speakeasy-api/openapi/values"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func TestSync_PrimitiveTypes_Success(t *testing.T) {

--- a/marshaller/tests/core/models.go
+++ b/marshaller/tests/core/models.go
@@ -8,7 +8,7 @@ import (
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/speakeasy-api/openapi/sequencedmap"
 	valuescore "github.com/speakeasy-api/openapi/values/core"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // TestPrimitiveModel covers all primitive marshaller.Node field types

--- a/marshaller/tests/models.go
+++ b/marshaller/tests/models.go
@@ -7,7 +7,7 @@ import (
 	"github.com/speakeasy-api/openapi/sequencedmap"
 	"github.com/speakeasy-api/openapi/values"
 	valuescore "github.com/speakeasy-api/openapi/values/core"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // High-level model counterparts for population testing using marshaller.Model

--- a/marshaller/unmarshalling_test.go
+++ b/marshaller/unmarshalling_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/speakeasy-api/openapi/validation"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func TestUnmarshal_PrimitiveTypes_Success(t *testing.T) {
@@ -177,7 +177,7 @@ boolField: "not a bool"
 intField: 42
 float64Field: 3.14
 `,
-			wantErrs: []string{"[3:12] error validation-type-mismatch testPrimitiveModel.boolField line 3: cannot unmarshal !!str `not a bool` into bool"},
+			wantErrs: []string{"[3:12] error validation-type-mismatch testPrimitiveModel.boolField line 3: cannot construct !!str `not a bool` into bool"},
 		},
 		{
 			name: "type mismatch - int field gets string",
@@ -187,7 +187,7 @@ boolField: true
 intField: "not an int"
 float64Field: 3.14
 `,
-			wantErrs: []string{"[4:11] error validation-type-mismatch testPrimitiveModel.intField line 4: cannot unmarshal !!str `not an int` into int"},
+			wantErrs: []string{"[4:11] error validation-type-mismatch testPrimitiveModel.intField line 4: cannot construct !!str `not an int` into int"},
 		},
 		{
 			name: "type mismatch - float field gets string",
@@ -197,7 +197,7 @@ boolField: true
 intField: 42
 float64Field: "not a float"
 `,
-			wantErrs: []string{"[5:15] error validation-type-mismatch testPrimitiveModel.float64Field line 5: cannot unmarshal !!str `not a f...` into float64"},
+			wantErrs: []string{"[5:15] error validation-type-mismatch testPrimitiveModel.float64Field line 5: cannot construct !!str `not a f...` into float64"},
 		},
 		{
 			name: "multiple validation errors",
@@ -208,8 +208,8 @@ intField: "not an int"
 			wantErrs: []string{
 				"[2:1] error validation-required-field `testPrimitiveModel.float64Field` is required",
 				"[2:1] error validation-required-field `testPrimitiveModel.stringField` is required",
-				"[2:12] error validation-type-mismatch testPrimitiveModel.boolField line 2: cannot unmarshal !!str `not a bool` into bool",
-				"[3:11] error validation-type-mismatch testPrimitiveModel.intField line 3: cannot unmarshal !!str `not an int` into int",
+				"[2:12] error validation-type-mismatch testPrimitiveModel.boolField line 2: cannot construct !!str `not a bool` into bool",
+				"[3:11] error validation-type-mismatch testPrimitiveModel.intField line 3: cannot construct !!str `not an int` into int",
 			},
 		},
 	}

--- a/openapi/bootstrap_test.go
+++ b/openapi/bootstrap_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/speakeasy-api/openapi/yml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func TestBootstrap_Success(t *testing.T) {

--- a/openapi/core/callbacks.go
+++ b/openapi/core/callbacks.go
@@ -4,7 +4,7 @@ import (
 	"github.com/speakeasy-api/openapi/extensions/core"
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/speakeasy-api/openapi/sequencedmap"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 type Callback struct {

--- a/openapi/core/callbacks_test.go
+++ b/openapi/core/callbacks_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func TestNewCallback_Success(t *testing.T) {

--- a/openapi/core/paths.go
+++ b/openapi/core/paths.go
@@ -4,7 +4,7 @@ import (
 	"github.com/speakeasy-api/openapi/extensions/core"
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/speakeasy-api/openapi/sequencedmap"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 type Paths struct {

--- a/openapi/core/paths_test.go
+++ b/openapi/core/paths_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func TestNewPaths_Success(t *testing.T) {

--- a/openapi/core/reference.go
+++ b/openapi/core/reference.go
@@ -10,7 +10,7 @@ import (
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/speakeasy-api/openapi/validation"
 	"github.com/speakeasy-api/openapi/yml"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 type Reference[T marshaller.CoreModeler] struct {

--- a/openapi/core/reference_test.go
+++ b/openapi/core/reference_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/speakeasy-api/openapi/pointer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func TestReference_Unmarshal_Success(t *testing.T) {

--- a/openapi/core/responses.go
+++ b/openapi/core/responses.go
@@ -4,7 +4,7 @@ import (
 	"github.com/speakeasy-api/openapi/extensions/core"
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/speakeasy-api/openapi/sequencedmap"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 type Responses struct {

--- a/openapi/core/responses_test.go
+++ b/openapi/core/responses_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func TestNewResponses_Success(t *testing.T) {

--- a/openapi/core/security.go
+++ b/openapi/core/security.go
@@ -4,7 +4,7 @@ import (
 	"github.com/speakeasy-api/openapi/extensions/core"
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/speakeasy-api/openapi/sequencedmap"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 type SecurityScheme struct {

--- a/openapi/core/security_test.go
+++ b/openapi/core/security_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func TestNewSecurityRequirement_Success(t *testing.T) {

--- a/openapi/index.go
+++ b/openapi/index.go
@@ -13,7 +13,7 @@ import (
 	"github.com/speakeasy-api/openapi/pointer"
 	"github.com/speakeasy-api/openapi/references"
 	"github.com/speakeasy-api/openapi/validation"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // CircularClassification represents the classification of a circular reference.

--- a/openapi/index_node_operation_test.go
+++ b/openapi/index_node_operation_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/speakeasy-api/openapi/references"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func TestBuildIndex_NodeToOperations_WithOption_Success(t *testing.T) {

--- a/openapi/linter/converter/generate.go
+++ b/openapi/linter/converter/generate.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/speakeasy-api/openapi/linter"
 	"github.com/speakeasy-api/openapi/validation"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // GenerateOptions configures the output generation.

--- a/openapi/linter/converter/generate_test.go
+++ b/openapi/linter/converter/generate_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/speakeasy-api/openapi/validation"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func TestGenerate_SpectralBasic(t *testing.T) {

--- a/openapi/linter/converter/parse.go
+++ b/openapi/linter/converter/parse.go
@@ -7,7 +7,7 @@ import (
 	"sort"
 	"strconv"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // Parse reads a Spectral, Vacuum, or Legacy Speakeasy config and returns

--- a/openapi/linter/converter/tests/go.mod
+++ b/openapi/linter/converter/tests/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/google/pprof v0.0.0-20230207041349-798e818bf904 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
+	go.yaml.in/yaml/v4 v4.0.0-rc.4 // indirect
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.36.0 // indirect
 	golang.org/x/text v0.34.0 // indirect

--- a/openapi/linter/converter/tests/go.sum
+++ b/openapi/linter/converter/tests/go.sum
@@ -26,6 +26,8 @@ github.com/speakeasy-api/jsonpath v0.6.3 h1:c+QPwzAOdrWvzycuc9HFsIZcxKIaWcNpC+xh
 github.com/speakeasy-api/jsonpath v0.6.3/go.mod h1:2cXloNuQ+RSXi5HTRaeBh7JEmjRXTiaKpFTdZiL7URI=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+go.yaml.in/yaml/v4 v4.0.0-rc.4 h1:UP4+v6fFrBIb1l934bDl//mmnoIZEDK0idg1+AIvX5U=
+go.yaml.in/yaml/v4 v4.0.0-rc.4/go.mod h1:aZqd9kCMsGL7AuUv/m/PvWLdg5sjJsZ4oHDEnfPPfY0=
 golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=
 golang.org/x/sync v0.19.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/openapi/linter/customrules/go.mod
+++ b/openapi/linter/customrules/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/go-sourcemap/sourcemap v2.1.4+incompatible
 	github.com/speakeasy-api/openapi v1.19.1-0.20260217225223-7d484a30828f
 	github.com/stretchr/testify v1.11.1
-	gopkg.in/yaml.v3 v3.0.1
+	go.yaml.in/yaml/v4 v4.0.0-rc.4
 )
 
 require (
@@ -23,4 +23,5 @@ require (
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.36.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/openapi/linter/customrules/go.sum
+++ b/openapi/linter/customrules/go.sum
@@ -27,6 +27,8 @@ github.com/speakeasy-api/jsonpath v0.6.3 h1:c+QPwzAOdrWvzycuc9HFsIZcxKIaWcNpC+xh
 github.com/speakeasy-api/jsonpath v0.6.3/go.mod h1:2cXloNuQ+RSXi5HTRaeBh7JEmjRXTiaKpFTdZiL7URI=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+go.yaml.in/yaml/v4 v4.0.0-rc.4 h1:UP4+v6fFrBIb1l934bDl//mmnoIZEDK0idg1+AIvX5U=
+go.yaml.in/yaml/v4 v4.0.0-rc.4/go.mod h1:aZqd9kCMsGL7AuUv/m/PvWLdg5sjJsZ4oHDEnfPPfY0=
 golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=
 golang.org/x/sync v0.19.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/openapi/linter/customrules/runtime.go
+++ b/openapi/linter/customrules/runtime.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/dop251/goja"
 	"github.com/speakeasy-api/openapi/validation"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // Runtime wraps a goja JavaScript runtime with custom rule support.

--- a/openapi/linter/linter_test.go
+++ b/openapi/linter/linter_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/speakeasy-api/openapi/validation"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 type mockVirtualFS struct {

--- a/openapi/linter/rules/description_duplication.go
+++ b/openapi/linter/rules/description_duplication.go
@@ -8,7 +8,7 @@ import (
 	"github.com/speakeasy-api/openapi/openapi"
 	"github.com/speakeasy-api/openapi/validation"
 	"github.com/speakeasy-api/openapi/yml"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 const RuleStyleDescriptionDuplication = "style-description-duplication"

--- a/openapi/linter/rules/duplicated_entry_in_enum.go
+++ b/openapi/linter/rules/duplicated_entry_in_enum.go
@@ -7,7 +7,7 @@ import (
 	"github.com/speakeasy-api/openapi/linter"
 	"github.com/speakeasy-api/openapi/openapi"
 	"github.com/speakeasy-api/openapi/validation"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 const RuleSemanticDuplicatedEnum = "semantic-duplicated-enum"

--- a/openapi/linter/rules/fix_helpers.go
+++ b/openapi/linter/rules/fix_helpers.go
@@ -8,7 +8,7 @@ import (
 	"github.com/speakeasy-api/openapi/openapi"
 	"github.com/speakeasy-api/openapi/validation"
 	"github.com/speakeasy-api/openapi/yml"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // addErrorResponseFix adds a skeleton error response to an operation's responses node.

--- a/openapi/linter/rules/fix_helpers_test.go
+++ b/openapi/linter/rules/fix_helpers_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/speakeasy-api/openapi/yml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // ============================================================

--- a/openapi/linter/rules/fix_integration_test.go
+++ b/openapi/linter/rules/fix_integration_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/speakeasy-api/openapi/validation"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // These integration tests verify that fixes actually resolve the violations

--- a/openapi/linter/rules/host_trailing_slash.go
+++ b/openapi/linter/rules/host_trailing_slash.go
@@ -8,7 +8,7 @@ import (
 	"github.com/speakeasy-api/openapi/linter"
 	"github.com/speakeasy-api/openapi/openapi"
 	"github.com/speakeasy-api/openapi/validation"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 const RuleStyleOAS3HostTrailingSlash = "style-oas3-host-trailing-slash"

--- a/openapi/linter/rules/markdown_descriptions.go
+++ b/openapi/linter/rules/markdown_descriptions.go
@@ -1,7 +1,7 @@
 package rules
 
 import (
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // GetFieldValueNode gets the YAML value node for a specific field from any object with a GetCore() method.

--- a/openapi/linter/rules/oas3_no_nullable.go
+++ b/openapi/linter/rules/oas3_no_nullable.go
@@ -8,7 +8,7 @@ import (
 	"github.com/speakeasy-api/openapi/openapi"
 	"github.com/speakeasy-api/openapi/validation"
 	"github.com/speakeasy-api/openapi/yml"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 const RuleOAS3NoNullable = "oas3-no-nullable"

--- a/openapi/linter/rules/oas_schema_check.go
+++ b/openapi/linter/rules/oas_schema_check.go
@@ -11,7 +11,7 @@ import (
 	"github.com/speakeasy-api/openapi/linter"
 	"github.com/speakeasy-api/openapi/openapi"
 	"github.com/speakeasy-api/openapi/validation"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 const RuleOasSchemaCheck = "oas-schema-check"

--- a/openapi/linter/rules/operation_success_response.go
+++ b/openapi/linter/rules/operation_success_response.go
@@ -9,7 +9,7 @@ import (
 	"github.com/speakeasy-api/openapi/linter"
 	"github.com/speakeasy-api/openapi/openapi"
 	"github.com/speakeasy-api/openapi/validation"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 const RuleStyleOperationSuccessResponse = "style-operation-success-response"

--- a/openapi/linter/rules/owasp_jwt_best_practices.go
+++ b/openapi/linter/rules/owasp_jwt_best_practices.go
@@ -9,7 +9,7 @@ import (
 	"github.com/speakeasy-api/openapi/openapi"
 	"github.com/speakeasy-api/openapi/validation"
 	"github.com/speakeasy-api/openapi/yml"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 const RuleOwaspJWTBestPractices = "owasp-jwt-best-practices"

--- a/openapi/linter/rules/owasp_no_additional_properties.go
+++ b/openapi/linter/rules/owasp_no_additional_properties.go
@@ -8,7 +8,7 @@ import (
 	"github.com/speakeasy-api/openapi/openapi"
 	"github.com/speakeasy-api/openapi/validation"
 	"github.com/speakeasy-api/openapi/yml"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 const RuleOwaspNoAdditionalProperties = "owasp-no-additional-properties"

--- a/openapi/linter/rules/owasp_security_hosts_https_oas3.go
+++ b/openapi/linter/rules/owasp_security_hosts_https_oas3.go
@@ -9,7 +9,7 @@ import (
 	"github.com/speakeasy-api/openapi/openapi"
 	"github.com/speakeasy-api/openapi/validation"
 	"github.com/speakeasy-api/openapi/yml"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 const RuleOwaspSecurityHostsHttpsOAS3 = "owasp-security-hosts-https-oas3"

--- a/openapi/linter/rules/path_trailing_slash.go
+++ b/openapi/linter/rules/path_trailing_slash.go
@@ -8,7 +8,7 @@ import (
 	"github.com/speakeasy-api/openapi/linter"
 	"github.com/speakeasy-api/openapi/openapi"
 	"github.com/speakeasy-api/openapi/validation"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 const RuleStylePathTrailingSlash = "style-path-trailing-slash"

--- a/openapi/linter/rules/rule_fixes_test.go
+++ b/openapi/linter/rules/rule_fixes_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/speakeasy-api/openapi/yml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // ============================================================

--- a/openapi/linter/rules/tags_alphabetical.go
+++ b/openapi/linter/rules/tags_alphabetical.go
@@ -10,7 +10,7 @@ import (
 	"github.com/speakeasy-api/openapi/openapi"
 	"github.com/speakeasy-api/openapi/validation"
 	"github.com/speakeasy-api/openapi/yml"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 const RuleStyleTagsAlphabetical = "style-tags-alphabetical"

--- a/openapi/linter/rules/typed_enum.go
+++ b/openapi/linter/rules/typed_enum.go
@@ -10,7 +10,7 @@ import (
 	"github.com/speakeasy-api/openapi/linter"
 	"github.com/speakeasy-api/openapi/openapi"
 	"github.com/speakeasy-api/openapi/validation"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 const RuleSemanticTypedEnum = "semantic-typed-enum"

--- a/openapi/linter/rules/unused_components.go
+++ b/openapi/linter/rules/unused_components.go
@@ -10,7 +10,7 @@ import (
 	"github.com/speakeasy-api/openapi/openapi"
 	"github.com/speakeasy-api/openapi/references"
 	"github.com/speakeasy-api/openapi/validation"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 const RuleSemanticUnusedComponent = "semantic-unused-component"

--- a/openapi/localize.go
+++ b/openapi/localize.go
@@ -14,7 +14,7 @@ import (
 	"github.com/speakeasy-api/openapi/references"
 	"github.com/speakeasy-api/openapi/sequencedmap"
 	"github.com/speakeasy-api/openapi/system"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // LocalizeNamingStrategy defines how external reference files should be named when localized.

--- a/openapi/openapi.go
+++ b/openapi/openapi.go
@@ -15,7 +15,7 @@ import (
 	"github.com/speakeasy-api/openapi/pointer"
 	"github.com/speakeasy-api/openapi/sequencedmap"
 	"github.com/speakeasy-api/openapi/validation"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // Version is the version of the OpenAPI Specification that this package conforms to.

--- a/openapi/openapi_examples_test.go
+++ b/openapi/openapi_examples_test.go
@@ -265,10 +265,10 @@ func Example_validating() {
 	//   [56:7] error validation-type-mismatch schema.examples expected `array`, got `object`
 	//   [59:15] error validation-type-mismatch schema.properties.name expected one of [`boolean`, `object`], got `string`
 	//   [59:15] error validation-type-mismatch schema.properties.name expected one of [`boolean`, `object`], got `string`
-	//   [59:15] error validation-type-mismatch schema.properties.name failed to validate either Schema [schema.properties.name expected `object`, got `str...`] or bool [schema.properties.name line 59: cannot unmarshal !!str `string` into bool]
+	//   [59:15] error validation-type-mismatch schema.properties.name failed to validate either Schema [schema.properties.name expected `object`, got `str...`] or bool [schema.properties.name line 59: cannot construct !!str `string` into bool]
 	//   [60:18] error validation-type-mismatch schema.properties.example expected one of [`boolean`, `object`], got `string`
 	//   [60:18] error validation-type-mismatch schema.properties.example expected one of [`boolean`, `object`], got `string`
-	//   [60:18] error validation-type-mismatch schema.properties.example failed to validate either Schema [schema.properties.example expected `object`, got `John Do...`] or bool [schema.properties.example line 60: cannot unmarshal !!str `John Doe` into bool]
+	//   [60:18] error validation-type-mismatch schema.properties.example failed to validate either Schema [schema.properties.example expected `object`, got `John Do...`] or bool [schema.properties.example line 60: cannot construct !!str `John Doe` into bool]
 	//   [63:9] error validation-type-mismatch schema.examples expected `sequence`, got `object`
 	//
 	// Fixing validation errors...

--- a/openapi/reference.go
+++ b/openapi/reference.go
@@ -14,7 +14,7 @@ import (
 	"github.com/speakeasy-api/openapi/pointer"
 	"github.com/speakeasy-api/openapi/references"
 	"github.com/speakeasy-api/openapi/validation"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 type (

--- a/openapi/sanitize.go
+++ b/openapi/sanitize.go
@@ -10,7 +10,7 @@ import (
 	"github.com/speakeasy-api/openapi/extensions"
 	"github.com/speakeasy-api/openapi/jsonschema/oas3"
 	"github.com/speakeasy-api/openapi/marshaller"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // ExtensionFilter specifies patterns for filtering extensions using allowed and denied lists.

--- a/openapi/upgrade.go
+++ b/openapi/upgrade.go
@@ -10,7 +10,7 @@ import (
 	"github.com/speakeasy-api/openapi/jsonschema/oas3"
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/speakeasy-api/openapi/sequencedmap"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 type UpgradeOptions struct {

--- a/openapi/upgrade_test.go
+++ b/openapi/upgrade_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/speakeasy-api/openapi/openapi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func TestUpgrade_Success(t *testing.T) {

--- a/overlay/apply.go
+++ b/overlay/apply.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/speakeasy-api/jsonpath/pkg/jsonpath/config"
 	"github.com/speakeasy-api/jsonpath/pkg/jsonpath/token"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // ApplyTo will take an overlay and apply its changes to the given YAML

--- a/overlay/apply_test.go
+++ b/overlay/apply_test.go
@@ -5,22 +5,15 @@ import (
 	"os"
 	"strconv"
 	"testing"
-	"unsafe"
 
 	"github.com/speakeasy-api/jsonpath/pkg/jsonpath"
+	"github.com/speakeasy-api/openapi/internal/testutils"
 	"github.com/speakeasy-api/openapi/overlay"
 	"github.com/speakeasy-api/openapi/overlay/loader"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.yaml.in/yaml/v4"
-	yamlv3 "gopkg.in/yaml.v3"
 )
-
-// queryV4 runs a jsonpath query using a v4 node by casting to v3 and back.
-func queryV4(path *jsonpath.JSONPath, node *yaml.Node) []*yaml.Node {
-	v3result := path.Query((*yamlv3.Node)(unsafe.Pointer(node)))
-	return *(*[]*yaml.Node)(unsafe.Pointer(&v3result))
-}
 
 // NodeMatchesFile is a test that marshals the YAML file from the given node,
 // then compares those bytes to those found in the expected file.
@@ -313,7 +306,7 @@ func TestApplyToOld(t *testing.T) {
 
 	path, err := jsonpath.NewPath(`$.paths["/anything/selectGlobalServer"]`)
 	require.NoError(t, err)
-	result := queryV4(path, nodeOld)
+	result := testutils.QueryV4(path, nodeOld)
 	require.NoError(t, err)
 	require.Empty(t, result)
 	o.JSONPathVersion = "rfc9535"
@@ -327,7 +320,7 @@ func TestApplyToOld(t *testing.T) {
 	o.Actions[0].Target = "$.paths[?(@[\"x-my-ignore\"])]" // @ should always refer to the child node in RFC 9535..
 	_, err = o.ApplyToStrict(nodeNew)
 	require.NoError(t, err)
-	result = queryV4(path, nodeNew)
+	result = testutils.QueryV4(path, nodeNew)
 	require.NoError(t, err)
 	require.Empty(t, result)
 }

--- a/overlay/compare.go
+++ b/overlay/compare.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // Compare compares input specifications from two files and returns an overlay

--- a/overlay/compare_test.go
+++ b/overlay/compare_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/speakeasy-api/openapi/overlay/loader"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func TestCompare(t *testing.T) {

--- a/overlay/format_test.go
+++ b/overlay/format_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/speakeasy-api/openapi/overlay"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func TestOverlay_Format_Success(t *testing.T) {

--- a/overlay/jsonpath.go
+++ b/overlay/jsonpath.go
@@ -2,17 +2,33 @@ package overlay
 
 import (
 	"fmt"
+	"unsafe"
 
 	"github.com/speakeasy-api/jsonpath/pkg/jsonpath"
 	"github.com/speakeasy-api/jsonpath/pkg/jsonpath/config"
 	"github.com/speakeasy-api/openapi/internal/version"
 	"github.com/vmware-labs/yaml-jsonpath/pkg/yamlpath"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
+	yamlv3 "gopkg.in/yaml.v3"
 )
 
 // Queryable is an interface for querying YAML nodes using JSONPath expressions.
 type Queryable interface {
 	Query(root *yaml.Node) []*yaml.Node
+}
+
+// nodeV4toV3 converts a *yaml.v4.Node to a *yaml.v3.Node via unsafe pointer cast.
+// This is safe because v4.Node is a strict superset of v3.Node — the first 12 fields
+// have identical types, sizes, and offsets. The v3 code never accesses the extra v4 fields.
+func nodeV4toV3(n *yaml.Node) *yamlv3.Node {
+	return (*yamlv3.Node)(unsafe.Pointer(n)) //nolint:gosec // v4.Node is a strict superset of v3.Node (verified via reflect)
+}
+
+// nodesV3toV4 converts a []*yaml.v3.Node slice to []*yaml.v4.Node.
+// The underlying pointer types have identical memory layouts so the slice header
+// can be reinterpreted directly.
+func nodesV3toV4(nodes []*yamlv3.Node) []*yaml.Node {
+	return *(*[]*yaml.Node)(unsafe.Pointer(&nodes)) //nolint:gosec // pointer types have identical memory layouts
 }
 
 type yamlPathQueryable struct {
@@ -24,8 +40,17 @@ func (y yamlPathQueryable) Query(root *yaml.Node) []*yaml.Node {
 		return []*yaml.Node{}
 	}
 	// errors aren't actually possible from yamlpath.
-	result, _ := y.path.Find(root)
-	return result
+	result, _ := y.path.Find(nodeV4toV3(root))
+	return nodesV3toV4(result)
+}
+
+// rfcJSONPathQueryable wraps a jsonpath.JSONPath to implement Queryable with v4 nodes.
+type rfcJSONPathQueryable struct {
+	path *jsonpath.JSONPath
+}
+
+func (r rfcJSONPathQueryable) Query(root *yaml.Node) []*yaml.Node {
+	return nodesV3toV4(r.path.Query(nodeV4toV3(root)))
 }
 
 // NewPath creates a new JSONPath queryable from the given target expression.
@@ -35,7 +60,10 @@ func (y yamlPathQueryable) Query(root *yaml.Node) []*yaml.Node {
 func (o *Overlay) NewPath(target string, warnings *[]string) (Queryable, error) {
 	rfcJSONPath, rfcJSONPathErr := jsonpath.NewPath(target, config.WithPropertyNameExtension())
 	if o.UsesRFC9535() {
-		return rfcJSONPath, rfcJSONPathErr
+		if rfcJSONPathErr != nil {
+			return nil, rfcJSONPathErr
+		}
+		return rfcJSONPathQueryable{path: rfcJSONPath}, nil
 	}
 
 	// For version < 1.1.0 without explicit rfc9535, warn about future incompatibility

--- a/overlay/loader/spec.go
+++ b/overlay/loader/spec.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	"github.com/speakeasy-api/openapi/overlay"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // GetOverlayExtendsPath returns the path to file if the extends URL is a file

--- a/overlay/loader/spec_test.go
+++ b/overlay/loader/spec_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/speakeasy-api/openapi/overlay"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // pathToFileURL converts a file path to a proper file:// URL

--- a/overlay/overlay_examples_test.go
+++ b/overlay/overlay_examples_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/speakeasy-api/openapi/overlay"
 	"github.com/speakeasy-api/openapi/overlay/loader"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // Example_applying demonstrates how to apply an overlay to an OpenAPI document.

--- a/overlay/parents.go
+++ b/overlay/parents.go
@@ -1,6 +1,6 @@
 package overlay
 
-import "gopkg.in/yaml.v3"
+import "go.yaml.in/yaml/v4"
 
 type parentIndex map[*yaml.Node]*yaml.Node
 

--- a/overlay/parse.go
+++ b/overlay/parse.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // ParseReader parses an overlay from the given reader.

--- a/overlay/schema.go
+++ b/overlay/schema.go
@@ -3,7 +3,7 @@ package overlay
 import (
 	"bytes"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // Version constants for the Overlay specification

--- a/overlay/upgrade_test.go
+++ b/overlay/upgrade_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/speakeasy-api/openapi/overlay"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func TestUpgrade_Success(t *testing.T) {

--- a/overlay/utils.go
+++ b/overlay/utils.go
@@ -3,7 +3,7 @@ package overlay
 import (
 	"fmt"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func NewTargetSelector(path, method string) string {

--- a/overlay/utils_test.go
+++ b/overlay/utils_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/speakeasy-api/openapi/overlay"
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func TestNewTargetSelector_Success(t *testing.T) {

--- a/overlay/validate_test.go
+++ b/overlay/validate_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/speakeasy-api/openapi/overlay"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func TestOverlay_Validate(t *testing.T) {

--- a/references/resolution.go
+++ b/references/resolution.go
@@ -12,7 +12,7 @@ import (
 	"github.com/speakeasy-api/openapi/internal/utils"
 	"github.com/speakeasy-api/openapi/jsonpointer"
 	"github.com/speakeasy-api/openapi/system"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 type ResolutionTarget interface {

--- a/references/resolution_test.go
+++ b/references/resolution_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/speakeasy-api/openapi/marshaller/tests"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // MockResolutionTarget implements ResolutionTarget for testing

--- a/sequencedmap/map.go
+++ b/sequencedmap/map.go
@@ -15,7 +15,7 @@ import (
 	"github.com/speakeasy-api/openapi/internal/interfaces"
 	"github.com/speakeasy-api/openapi/internal/utils"
 	"github.com/speakeasy-api/openapi/yml"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // OrderType represents the different ways to order iteration through the map

--- a/sequencedmap/map_advanced_test.go
+++ b/sequencedmap/map_advanced_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func TestMap_NavigateWithKey_Success(t *testing.T) {

--- a/sequencedmap/yaml_unmarshal_test.go
+++ b/sequencedmap/yaml_unmarshal_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/speakeasy-api/openapi/sequencedmap"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func TestSequencedMap_Standard_Yaml_Unmarshal(t *testing.T) {

--- a/swagger/core/paths.go
+++ b/swagger/core/paths.go
@@ -4,7 +4,7 @@ import (
 	"github.com/speakeasy-api/openapi/extensions/core"
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/speakeasy-api/openapi/sequencedmap"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // Paths holds the relative paths to the individual endpoints.

--- a/swagger/core/paths_test.go
+++ b/swagger/core/paths_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func parseYAML(t *testing.T, yml string) *yaml.Node {

--- a/swagger/core/reference.go
+++ b/swagger/core/reference.go
@@ -10,7 +10,7 @@ import (
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/speakeasy-api/openapi/validation"
 	"github.com/speakeasy-api/openapi/yml"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // Reference represents either a reference to a component or an inline object.

--- a/swagger/core/reference_test.go
+++ b/swagger/core/reference_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func TestReference_Unmarshal_Success(t *testing.T) {

--- a/swagger/core/response.go
+++ b/swagger/core/response.go
@@ -6,7 +6,7 @@ import (
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/speakeasy-api/openapi/sequencedmap"
 	values "github.com/speakeasy-api/openapi/values/core"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // Responses is a container for the expected responses of an operation.

--- a/swagger/core/response_test.go
+++ b/swagger/core/response_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func TestNewResponses_Success(t *testing.T) {

--- a/swagger/roundtrip_test.go
+++ b/swagger/roundtrip_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/speakeasy-api/openapi/yml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 type roundTripTest struct {

--- a/validation/errors.go
+++ b/validation/errors.go
@@ -3,7 +3,7 @@ package validation
 import (
 	"fmt"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 type Severity string

--- a/validation/fix.go
+++ b/validation/fix.go
@@ -1,6 +1,6 @@
 package validation
 
-import "gopkg.in/yaml.v3"
+import "go.yaml.in/yaml/v4"
 
 // PromptType describes what kind of user input a fix needs.
 type PromptType int

--- a/validation/utils_test.go
+++ b/validation/utils_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // Test SortValidationErrors function

--- a/validation/validation_test.go
+++ b/validation/validation_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 // Test the Error type methods

--- a/values/core/eithervalue.go
+++ b/values/core/eithervalue.go
@@ -10,7 +10,7 @@ import (
 	"github.com/speakeasy-api/openapi/internal/interfaces"
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/speakeasy-api/openapi/validation"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 type EitherValue[L any, R any] struct {

--- a/values/core/eithervalue_test.go
+++ b/values/core/eithervalue_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/speakeasy-api/openapi/validation"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 type TestEitherValue[L any, R any] struct {

--- a/values/core/value.go
+++ b/values/core/value.go
@@ -1,6 +1,6 @@
 package core
 
-import "gopkg.in/yaml.v3"
+import "go.yaml.in/yaml/v4"
 
 // Value represents a raw value in an OpenAPI or Arazzo document.
 type Value = *yaml.Node

--- a/values/value.go
+++ b/values/value.go
@@ -1,6 +1,6 @@
 package values
 
-import "gopkg.in/yaml.v3"
+import "go.yaml.in/yaml/v4"
 
 // Value represents a raw value in an OpenAPI or Arazzo document.
 type Value = *yaml.Node

--- a/yml/config.go
+++ b/yml/config.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"strconv"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 type contextKey string

--- a/yml/config_test.go
+++ b/yml/config_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/speakeasy-api/openapi/yml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func TestContextKey_String_Success(t *testing.T) {

--- a/yml/nodekind.go
+++ b/yml/nodekind.go
@@ -1,6 +1,6 @@
 package yml
 
-import "gopkg.in/yaml.v3"
+import "go.yaml.in/yaml/v4"
 
 // NodeKindToString returns a human-readable string representation of a yaml.Kind.
 // This helper function is useful for creating more user-friendly error messages

--- a/yml/nodekind_test.go
+++ b/yml/nodekind_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/speakeasy-api/openapi/yml"
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func TestNodeKindToString(t *testing.T) {

--- a/yml/walk.go
+++ b/yml/walk.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/speakeasy-api/openapi/errors"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 const (

--- a/yml/walk_test.go
+++ b/yml/walk_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/speakeasy-api/openapi/yml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func TestWalk_Success(t *testing.T) {

--- a/yml/yml.go
+++ b/yml/yml.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"strconv"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func CreateOrUpdateKeyNode(ctx context.Context, key string, keyNode *yaml.Node) *yaml.Node {

--- a/yml/yml_test.go
+++ b/yml/yml_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/speakeasy-api/openapi/yml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func TestCreateOrUpdateKeyNode_Success(t *testing.T) {


### PR DESCRIPTION
## Summary

- Upgrade YAML library from `gopkg.in/yaml.v3` to `go.yaml.in/yaml/v4` (v4.0.0-rc.4) across 160+ files
- Add unsafe pointer bridge in `overlay/jsonpath.go` for jsonpath libraries that still use yaml.v3 `*Node` types
- Update `yaml.TypeError` → `yaml.LoadErrors` in marshaller to use non-deprecated API
- Update test assertions for v4 error message changes (`"cannot unmarshal"` → `"cannot construct"`) and type name changes (`*yaml.Node` → `*libyaml.Node`)

## Notes

- `gopkg.in/yaml.v3` remains as a **direct** dependency in `overlay/jsonpath.go` (for the v3↔v4 bridge used by jsonpath libraries) and as an indirect dependency for `vmware-labs/yaml-jsonpath` and `speakeasy-api/jsonpath` which still use v3 in their APIs. These can be forked/upgraded separately.
- The v3→v4 `unsafe.Pointer` cast is guarded by an `init()` function that uses `reflect` to verify the first 12 fields of v4.Node match v3.Node in name, offset, and size. If a future v4 release changes the struct layout, the guard will panic at startup rather than causing silent corruption.
- yaml v4 is currently at `v4.0.0-rc.4` (release candidate)

## Test plan

- [x] All 41 packages pass `go test -count=1 ./...`
- [x] `mise ci` passes (format, lint, mod-tidy, test, integration, build)