### PR TITLE
fix: replace gopkg.in/yaml.v3 with go.yaml.in/yaml/v3

### DIFF
--- a/arazzo/arazzo_order_test.go
+++ b/arazzo/arazzo_order_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/speakeasy-api/openapi/expression"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestArazzo_ArrayOrdering_ReorderWorkflows_Success(t *testing.T) {

--- a/arazzo/arazzo_test.go
+++ b/arazzo/arazzo_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/speakeasy-api/openapi/yml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // TODO make it possible to choose json or yaml output

--- a/arazzo/core/criterion.go
+++ b/arazzo/core/criterion.go
@@ -11,7 +11,7 @@ import (
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/speakeasy-api/openapi/validation"
 	"github.com/speakeasy-api/openapi/yml"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 type CriterionExpressionType struct {

--- a/arazzo/core/criterion_syncchanges_test.go
+++ b/arazzo/core/criterion_syncchanges_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/speakeasy-api/openapi/pointer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestCriterionTypeUnion_SyncChanges_WithStringType_Success(t *testing.T) {

--- a/arazzo/core/criterion_test.go
+++ b/arazzo/core/criterion_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/speakeasy-api/openapi/pointer"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func createCriterionWithRootNode(c Criterion, rootNode *yaml.Node) Criterion {

--- a/arazzo/core/reusable.go
+++ b/arazzo/core/reusable.go
@@ -11,7 +11,7 @@ import (
 	"github.com/speakeasy-api/openapi/validation"
 	values "github.com/speakeasy-api/openapi/values/core"
 	"github.com/speakeasy-api/openapi/yml"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 type Reusable[T marshaller.CoreModeler] struct {

--- a/arazzo/core/reusable_test.go
+++ b/arazzo/core/reusable_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestReusable_Unmarshal_WithReference_Success(t *testing.T) {

--- a/arazzo/criterion/condition.go
+++ b/arazzo/criterion/condition.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/speakeasy-api/openapi/expression"
 	"github.com/speakeasy-api/openapi/validation"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // Operator represents the operator used to compare the value of a criterion.

--- a/arazzo/requestbody_test.go
+++ b/arazzo/requestbody_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/speakeasy-api/openapi/pointer"
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestRequestBody_Validate_JSONPathInPayload_Success(t *testing.T) {

--- a/arazzo/reusable.go
+++ b/arazzo/reusable.go
@@ -15,7 +15,7 @@ import (
 	"github.com/speakeasy-api/openapi/sequencedmap"
 	"github.com/speakeasy-api/openapi/validation"
 	"github.com/speakeasy-api/openapi/values"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 type (

--- a/arazzo/successaction.go
+++ b/arazzo/successaction.go
@@ -15,7 +15,7 @@ import (
 	"github.com/speakeasy-api/openapi/pointer"
 	"github.com/speakeasy-api/openapi/validation"
 	walkpkg "github.com/speakeasy-api/openapi/walk"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // SuccessActionType represents the type of action to take on success.

--- a/cmd/openapi/commands/openapi/bootstrap.go
+++ b/cmd/openapi/commands/openapi/bootstrap.go
@@ -8,7 +8,7 @@ import (
 	"github.com/speakeasy-api/openapi/openapi"
 	"github.com/speakeasy-api/openapi/yml"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 var bootstrapCmd = &cobra.Command{

--- a/cmd/openapi/commands/overlay/apply.go
+++ b/cmd/openapi/commands/overlay/apply.go
@@ -8,7 +8,7 @@ import (
 	overlayPkg "github.com/speakeasy-api/openapi/overlay"
 	"github.com/speakeasy-api/openapi/overlay/loader"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 var (

--- a/cmd/openapi/commands/overlay/compare.go
+++ b/cmd/openapi/commands/overlay/compare.go
@@ -8,7 +8,7 @@ import (
 	overlayPkg "github.com/speakeasy-api/openapi/overlay"
 	"github.com/speakeasy-api/openapi/overlay/loader"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 var (

--- a/cmd/openapi/go.mod
+++ b/cmd/openapi/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260408022107-7a9aee7c092c
 	github.com/spf13/cobra v1.10.1
 	github.com/stretchr/testify v1.11.1
-	gopkg.in/yaml.v3 v3.0.1
+	go.yaml.in/yaml/v3 v3.0.4
 )
 
 require (
@@ -46,4 +46,5 @@ require (
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.36.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/cmd/openapi/go.sum
+++ b/cmd/openapi/go.sum
@@ -101,6 +101,8 @@ github.com/vmware-labs/yaml-jsonpath v0.3.2 h1:/5QKeCBGdsInyDCyVNLbXyilb61MXGi9N
 github.com/vmware-labs/yaml-jsonpath v0.3.2/go.mod h1:U6whw1z03QyqgWdgXxvVnQ90zN1BWz5V+51Ewf8k+rQ=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
+go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561 h1:MDc5xs78ZrZr3HMQugiXOAkSZtfTpbJLDr/lwfgO53E=
 golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/expression/core/value.go
+++ b/expression/core/value.go
@@ -1,5 +1,5 @@
 package core
 
-import "gopkg.in/yaml.v3"
+import "go.yaml.in/yaml/v3"
 
 type ValueOrExpression = *yaml.Node

--- a/expression/value.go
+++ b/expression/value.go
@@ -1,7 +1,7 @@
 package expression
 
 import (
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // ValueOrExpression represents a raw value or expression in the Arazzo document.

--- a/expression/value_test.go
+++ b/expression/value_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/speakeasy-api/openapi/expression"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestGetValueOrExpressionValue_Success(t *testing.T) {

--- a/extensions/core/extensions.go
+++ b/extensions/core/extensions.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/speakeasy-api/openapi/sequencedmap"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 type (

--- a/extensions/core/extensions_test.go
+++ b/extensions/core/extensions_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/speakeasy-api/openapi/sequencedmap"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 type TestCoreModel struct {

--- a/extensions/extensions.go
+++ b/extensions/extensions.go
@@ -10,7 +10,7 @@ import (
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/speakeasy-api/openapi/sequencedmap"
 	"github.com/speakeasy-api/openapi/yml"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 const (

--- a/extensions/extensions_isequal_test.go
+++ b/extensions/extensions_isequal_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestExtensions_IsEqual_Success(t *testing.T) {

--- a/extensions/extensions_test.go
+++ b/extensions/extensions_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/speakeasy-api/openapi/sequencedmap"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 type ModelWithExtensions struct {

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/vmware-labs/yaml-jsonpath v0.3.2
 	golang.org/x/sync v0.20.0
 	golang.org/x/text v0.35.0
-	gopkg.in/yaml.v3 v3.0.1
+	go.yaml.in/yaml/v3 v3.0.4
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -7,9 +7,9 @@ require (
 	github.com/speakeasy-api/jsonpath v0.6.3
 	github.com/stretchr/testify v1.11.1
 	github.com/vmware-labs/yaml-jsonpath v0.3.2
+	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/sync v0.20.0
 	golang.org/x/text v0.35.0
-	go.yaml.in/yaml/v3 v3.0.4
 )
 
 require (
@@ -21,4 +21,5 @@ require (
 	golang.org/x/net v0.42.0 // indirect
 	golang.org/x/sys v0.36.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/vmware-labs/yaml-jsonpath v0.3.2 h1:/5QKeCBGdsInyDCyVNLbXyilb61MXGi9NP674f9Hobk=
 github.com/vmware-labs/yaml-jsonpath v0.3.2/go.mod h1:U6whw1z03QyqgWdgXxvVnQ90zN1BWz5V+51Ewf8k+rQ=
+go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.42.0 h1:jzkYrhi3YQWD6MLBJcsklgQsoAcw89EcZbJw8Z614hs=
 golang.org/x/net v0.42.0/go.mod h1:FF1RA5d3u7nAYA4z2TkclSCKh68eSXtiFwcWQpPXdt8=

--- a/hashing/hashing.go
+++ b/hashing/hashing.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/speakeasy-api/openapi/internal/interfaces"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func Hash(v any) string {

--- a/hashing/hashing_test.go
+++ b/hashing/hashing_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/speakeasy-api/openapi/yml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 type testEnum string

--- a/internal/interfaces/interfaces.go
+++ b/internal/interfaces/interfaces.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 
 	"github.com/speakeasy-api/openapi/validation"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 type Validator[T any] interface {

--- a/internal/interfaces/interfaces_test.go
+++ b/internal/interfaces/interfaces_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/speakeasy-api/openapi/validation"
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // Test implementations for Model interface

--- a/internal/testutils/utils.go
+++ b/internal/testutils/utils.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/speakeasy-api/openapi/yml"
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // TODO use these more in tests

--- a/internal/testutils/utils_test.go
+++ b/internal/testutils/utils_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestCreateStringYamlNode_Success(t *testing.T) {

--- a/json/json.go
+++ b/json/json.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/speakeasy-api/openapi/yml"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // YAMLToJSON converts a YAML node to JSON using a custom JSON writer that preserves formatting.

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/speakeasy-api/openapi/json"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestYAMLToJSON_Success(t *testing.T) {

--- a/jsonpointer/jsonpointer.go
+++ b/jsonpointer/jsonpointer.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/speakeasy-api/openapi/errors"
 	"github.com/speakeasy-api/openapi/internal/interfaces"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 const (

--- a/jsonpointer/models_yaml_fallback_test.go
+++ b/jsonpointer/models_yaml_fallback_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // TestModel represents a simple model for testing YAML fallback

--- a/jsonpointer/yamlnode.go
+++ b/jsonpointer/yamlnode.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func getYamlNodeTarget(node *yaml.Node, currentPart navigationPart, stack []navigationPart, currentPath string, o *options) (any, []navigationPart, error) {

--- a/jsonpointer/yamlnode_test.go
+++ b/jsonpointer/yamlnode_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestGetTarget_YamlNode_Success(t *testing.T) {

--- a/jsonschema/oas3/core/jsonschema_test.go
+++ b/jsonschema/oas3/core/jsonschema_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestJSONSchema_Unmarshal_BooleanValue_Success(t *testing.T) {

--- a/jsonschema/oas3/core/xml_test.go
+++ b/jsonschema/oas3/core/xml_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func parseYAML(t *testing.T, yml string) *yaml.Node {

--- a/jsonschema/oas3/resolution.go
+++ b/jsonschema/oas3/resolution.go
@@ -9,7 +9,7 @@ import (
 	"github.com/speakeasy-api/openapi/internal/utils"
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/speakeasy-api/openapi/references"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // ResolveOptions represent the options available when resolving a JSON Schema reference.

--- a/jsonschema/oas3/resolution_defs.go
+++ b/jsonschema/oas3/resolution_defs.go
@@ -8,7 +8,7 @@ import (
 	"github.com/speakeasy-api/openapi/internal/utils"
 	"github.com/speakeasy-api/openapi/jsonpointer"
 	"github.com/speakeasy-api/openapi/references"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // GetRootNoder is an interface for objects that can return a YAML root node.

--- a/jsonschema/oas3/resolution_defs_test.go
+++ b/jsonschema/oas3/resolution_defs_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/speakeasy-api/openapi/references"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestTryResolveLocalDefs_NilAndBooleanSchema(t *testing.T) {

--- a/jsonschema/oas3/resolution_external.go
+++ b/jsonschema/oas3/resolution_external.go
@@ -9,7 +9,7 @@ import (
 	"github.com/speakeasy-api/openapi/jsonpointer"
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/speakeasy-api/openapi/references"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // resolveExternalAnchorReference handles resolution of anchor references (e.g., "file.json#anchor")

--- a/jsonschema/oas3/resolution_external_test.go
+++ b/jsonschema/oas3/resolution_external_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestResolveExternalAnchorReference_Success(t *testing.T) {

--- a/jsonschema/oas3/resolution_test.go
+++ b/jsonschema/oas3/resolution_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/speakeasy-api/openapi/references"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // MockResolutionTarget implements references.ResolutionTarget for testing

--- a/jsonschema/oas3/schema_getters_test.go
+++ b/jsonschema/oas3/schema_getters_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/speakeasy-api/openapi/sequencedmap"
 	"github.com/speakeasy-api/openapi/values"
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestSchema_GetExclusiveMaximum_Success(t *testing.T) {

--- a/jsonschema/oas3/schema_isequal_test.go
+++ b/jsonschema/oas3/schema_isequal_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/speakeasy-api/openapi/sequencedmap"
 	"github.com/speakeasy-api/openapi/values"
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestSchema_IsEqual_Success(t *testing.T) {

--- a/jsonschema/oas3/tests/go.mod
+++ b/jsonschema/oas3/tests/go.mod
@@ -61,6 +61,7 @@ require (
 	go.opentelemetry.io/otel/metric v1.41.0 // indirect
 	go.opentelemetry.io/otel/trace v1.41.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.7.1 // indirect
+	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.48.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect

--- a/jsonschema/oas3/tests/go.sum
+++ b/jsonschema/oas3/tests/go.sum
@@ -137,6 +137,8 @@ go.opentelemetry.io/otel/trace v1.41.0 h1:Vbk2co6bhj8L59ZJ6/xFTskY+tGAbOnCtQGVVa
 go.opentelemetry.io/otel/trace v1.41.0/go.mod h1:U1NU4ULCoxeDKc09yCWdWe+3QoyweJcISEVa1RBzOis=
 go.opentelemetry.io/proto/otlp v1.7.1 h1:gTOMpGDb0WTBOP8JaO72iL3auEZhVmAQg4ipjOVAtj4=
 go.opentelemetry.io/proto/otlp v1.7.1/go.mod h1:b2rVh6rfI/s2pHWNlB7ILJcRALpcNDzKhACevjI+ZnE=
+go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.48.0 h1:/VRzVqiRSggnhY7gNRxPauEQ5Drw9haKdM0jqfcCFts=
 golang.org/x/crypto v0.48.0/go.mod h1:r0kV5h3qnFPlQnBSrULhlsRfryS2pmewsg+XfMgkVos=
 golang.org/x/net v0.49.0 h1:eeHFmOGUTtaaPSGNmjBKpbng9MulQsJURQUAfUwY++o=

--- a/jsonschema/oas3/validation.go
+++ b/jsonschema/oas3/validation.go
@@ -17,9 +17,9 @@ import (
 	"github.com/speakeasy-api/openapi/jsonschema/oas3/core"
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/speakeasy-api/openapi/validation"
+	"go.yaml.in/yaml/v3"
 	"golang.org/x/text/language"
 	"golang.org/x/text/message"
-	"go.yaml.in/yaml/v3"
 )
 
 // custom file to cover for missing openapi 3.0 json schema

--- a/jsonschema/oas3/validation.go
+++ b/jsonschema/oas3/validation.go
@@ -19,7 +19,7 @@ import (
 	"github.com/speakeasy-api/openapi/validation"
 	"golang.org/x/text/language"
 	"golang.org/x/text/message"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // custom file to cover for missing openapi 3.0 json schema

--- a/linter/config.go
+++ b/linter/config.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/speakeasy-api/openapi/references"
 	"github.com/speakeasy-api/openapi/validation"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // Config represents the linter configuration

--- a/linter/config_loader.go
+++ b/linter/config_loader.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"os"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // LoadConfig loads lint configuration from a YAML reader.

--- a/linter/fix/engine.go
+++ b/linter/fix/engine.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/speakeasy-api/openapi/openapi"
 	"github.com/speakeasy-api/openapi/validation"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // Mode controls how fixes are applied.

--- a/linter/fix/engine_test.go
+++ b/linter/fix/engine_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/speakeasy-api/openapi/validation"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // mockFix is a non-interactive fix for testing.

--- a/linter/fix/terminal_prompter_test.go
+++ b/linter/fix/terminal_prompter_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/speakeasy-api/openapi/validation"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestTerminalPrompter_Choice_Success(t *testing.T) {

--- a/linter/format/format_test.go
+++ b/linter/format/format_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/speakeasy-api/openapi/validation"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // testFix is a minimal validation.Fix for testing formatter output.

--- a/marshaller/coremodel.go
+++ b/marshaller/coremodel.go
@@ -11,7 +11,7 @@ import (
 	"github.com/speakeasy-api/openapi/json"
 	"github.com/speakeasy-api/openapi/validation"
 	"github.com/speakeasy-api/openapi/yml"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 type CoreModeler interface {

--- a/marshaller/coremodel_getters_test.go
+++ b/marshaller/coremodel_getters_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestCoreModel_GetRootNodeLine_Success(t *testing.T) {

--- a/marshaller/coremodel_jsonpath_test.go
+++ b/marshaller/coremodel_jsonpath_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestCoreModel_GetJSONPath_Success(t *testing.T) {

--- a/marshaller/coremodel_jsonpointer_test.go
+++ b/marshaller/coremodel_jsonpointer_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestCoreModel_GetJSONPointer_Success(t *testing.T) {

--- a/marshaller/extensions.go
+++ b/marshaller/extensions.go
@@ -9,7 +9,7 @@ import (
 	"unsafe"
 
 	"github.com/speakeasy-api/openapi/yml"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 type Extension = *yaml.Node

--- a/marshaller/factory.go
+++ b/marshaller/factory.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 
 	"github.com/speakeasy-api/openapi/sequencedmap"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // TypeFactory represents a function that creates a new instance of a specific type

--- a/marshaller/marshal.go
+++ b/marshaller/marshal.go
@@ -6,7 +6,7 @@ import (
 	"io"
 
 	"github.com/speakeasy-api/openapi/yml"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // Marshallable represents a high-level model that can be marshaled

--- a/marshaller/model.go
+++ b/marshaller/model.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"sync"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // CoreAccessor provides type-safe access to the core field in models

--- a/marshaller/model_test.go
+++ b/marshaller/model_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/speakeasy-api/openapi/marshaller/tests/core"
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // TestModel_GetPropertyNode_Success tests the GetPropertyNode method with valid inputs

--- a/marshaller/node.go
+++ b/marshaller/node.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 
 	"github.com/speakeasy-api/openapi/yml"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 type NodeMutator interface {

--- a/marshaller/node_test.go
+++ b/marshaller/node_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 type testCase[T any] struct {

--- a/marshaller/nodecollector.go
+++ b/marshaller/nodecollector.go
@@ -3,7 +3,7 @@ package marshaller
 import (
 	"reflect"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // NodeCollector provides utilities for collecting yaml.Node pointers from core models.

--- a/marshaller/nodecollector_test.go
+++ b/marshaller/nodecollector_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // Test models to verify CollectLeafNodes behavior

--- a/marshaller/populator.go
+++ b/marshaller/populator.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 
 	"github.com/speakeasy-api/openapi/internal/interfaces"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // Pre-computed reflection types for performance

--- a/marshaller/populator_unmarshalextensionmodel_test.go
+++ b/marshaller/populator_unmarshalextensionmodel_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/speakeasy-api/openapi/sequencedmap"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func init() {

--- a/marshaller/sequencedmap.go
+++ b/marshaller/sequencedmap.go
@@ -12,8 +12,8 @@ import (
 	"github.com/speakeasy-api/openapi/internal/utils"
 	"github.com/speakeasy-api/openapi/validation"
 	"github.com/speakeasy-api/openapi/yml"
-	"golang.org/x/sync/errgroup"
 	"go.yaml.in/yaml/v3"
+	"golang.org/x/sync/errgroup"
 )
 
 // MapGetter interface for syncing operations

--- a/marshaller/sequencedmap.go
+++ b/marshaller/sequencedmap.go
@@ -13,7 +13,7 @@ import (
 	"github.com/speakeasy-api/openapi/validation"
 	"github.com/speakeasy-api/openapi/yml"
 	"golang.org/x/sync/errgroup"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // MapGetter interface for syncing operations

--- a/marshaller/sequencedmap_test.go
+++ b/marshaller/sequencedmap_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/speakeasy-api/openapi/sequencedmap"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // SequencedMap test case for successful operations

--- a/marshaller/syncer.go
+++ b/marshaller/syncer.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/speakeasy-api/openapi/internal/interfaces"
 	"github.com/speakeasy-api/openapi/yml"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 type Syncer interface {

--- a/marshaller/syncing_test.go
+++ b/marshaller/syncing_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/speakeasy-api/openapi/sequencedmap"
 	"github.com/speakeasy-api/openapi/values"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestSync_PrimitiveTypes_Success(t *testing.T) {

--- a/marshaller/tests/core/models.go
+++ b/marshaller/tests/core/models.go
@@ -8,7 +8,7 @@ import (
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/speakeasy-api/openapi/sequencedmap"
 	valuescore "github.com/speakeasy-api/openapi/values/core"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // TestPrimitiveModel covers all primitive marshaller.Node field types

--- a/marshaller/tests/models.go
+++ b/marshaller/tests/models.go
@@ -7,7 +7,7 @@ import (
 	"github.com/speakeasy-api/openapi/sequencedmap"
 	"github.com/speakeasy-api/openapi/values"
 	valuescore "github.com/speakeasy-api/openapi/values/core"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // High-level model counterparts for population testing using marshaller.Model

--- a/marshaller/unmarshaller.go
+++ b/marshaller/unmarshaller.go
@@ -13,7 +13,7 @@ import (
 	"github.com/speakeasy-api/openapi/validation"
 	"github.com/speakeasy-api/openapi/yml"
 	"golang.org/x/sync/errgroup"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // Pre-computed reflection types for performance (reusing from populator.go where possible)

--- a/marshaller/unmarshaller.go
+++ b/marshaller/unmarshaller.go
@@ -12,8 +12,8 @@ import (
 	"github.com/speakeasy-api/openapi/internal/interfaces"
 	"github.com/speakeasy-api/openapi/validation"
 	"github.com/speakeasy-api/openapi/yml"
-	"golang.org/x/sync/errgroup"
 	"go.yaml.in/yaml/v3"
+	"golang.org/x/sync/errgroup"
 )
 
 // Pre-computed reflection types for performance (reusing from populator.go where possible)

--- a/marshaller/unmarshalling_test.go
+++ b/marshaller/unmarshalling_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/speakeasy-api/openapi/validation"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestUnmarshal_PrimitiveTypes_Success(t *testing.T) {

--- a/openapi/bootstrap_test.go
+++ b/openapi/bootstrap_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/speakeasy-api/openapi/yml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestBootstrap_Success(t *testing.T) {

--- a/openapi/core/callbacks.go
+++ b/openapi/core/callbacks.go
@@ -4,7 +4,7 @@ import (
 	"github.com/speakeasy-api/openapi/extensions/core"
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/speakeasy-api/openapi/sequencedmap"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 type Callback struct {

--- a/openapi/core/callbacks_test.go
+++ b/openapi/core/callbacks_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestNewCallback_Success(t *testing.T) {

--- a/openapi/core/paths.go
+++ b/openapi/core/paths.go
@@ -4,7 +4,7 @@ import (
 	"github.com/speakeasy-api/openapi/extensions/core"
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/speakeasy-api/openapi/sequencedmap"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 type Paths struct {

--- a/openapi/core/paths_test.go
+++ b/openapi/core/paths_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestNewPaths_Success(t *testing.T) {

--- a/openapi/core/reference.go
+++ b/openapi/core/reference.go
@@ -10,7 +10,7 @@ import (
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/speakeasy-api/openapi/validation"
 	"github.com/speakeasy-api/openapi/yml"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 type Reference[T marshaller.CoreModeler] struct {

--- a/openapi/core/reference_test.go
+++ b/openapi/core/reference_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/speakeasy-api/openapi/pointer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestReference_Unmarshal_Success(t *testing.T) {

--- a/openapi/core/responses.go
+++ b/openapi/core/responses.go
@@ -4,7 +4,7 @@ import (
 	"github.com/speakeasy-api/openapi/extensions/core"
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/speakeasy-api/openapi/sequencedmap"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 type Responses struct {

--- a/openapi/core/responses_test.go
+++ b/openapi/core/responses_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestNewResponses_Success(t *testing.T) {

--- a/openapi/core/security.go
+++ b/openapi/core/security.go
@@ -4,7 +4,7 @@ import (
 	"github.com/speakeasy-api/openapi/extensions/core"
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/speakeasy-api/openapi/sequencedmap"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 type SecurityScheme struct {

--- a/openapi/core/security_test.go
+++ b/openapi/core/security_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestNewSecurityRequirement_Success(t *testing.T) {

--- a/openapi/index.go
+++ b/openapi/index.go
@@ -13,7 +13,7 @@ import (
 	"github.com/speakeasy-api/openapi/pointer"
 	"github.com/speakeasy-api/openapi/references"
 	"github.com/speakeasy-api/openapi/validation"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // CircularClassification represents the classification of a circular reference.

--- a/openapi/index_node_operation_test.go
+++ b/openapi/index_node_operation_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/speakeasy-api/openapi/references"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestBuildIndex_NodeToOperations_WithOption_Success(t *testing.T) {

--- a/openapi/linter/converter/generate.go
+++ b/openapi/linter/converter/generate.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/speakeasy-api/openapi/linter"
 	"github.com/speakeasy-api/openapi/validation"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // GenerateOptions configures the output generation.

--- a/openapi/linter/converter/generate_test.go
+++ b/openapi/linter/converter/generate_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/speakeasy-api/openapi/validation"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestGenerate_SpectralBasic(t *testing.T) {

--- a/openapi/linter/converter/parse.go
+++ b/openapi/linter/converter/parse.go
@@ -7,7 +7,7 @@ import (
 	"sort"
 	"strconv"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // Parse reads a Spectral, Vacuum, or Legacy Speakeasy config and returns

--- a/openapi/linter/converter/tests/go.mod
+++ b/openapi/linter/converter/tests/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/google/pprof v0.0.0-20230207041349-798e818bf904 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
+	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.36.0 // indirect
 	golang.org/x/text v0.35.0 // indirect

--- a/openapi/linter/converter/tests/go.sum
+++ b/openapi/linter/converter/tests/go.sum
@@ -26,6 +26,8 @@ github.com/speakeasy-api/jsonpath v0.6.3 h1:c+QPwzAOdrWvzycuc9HFsIZcxKIaWcNpC+xh
 github.com/speakeasy-api/jsonpath v0.6.3/go.mod h1:2cXloNuQ+RSXi5HTRaeBh7JEmjRXTiaKpFTdZiL7URI=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
 golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/openapi/linter/customrules/go.mod
+++ b/openapi/linter/customrules/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/go-sourcemap/sourcemap v2.1.4+incompatible
 	github.com/speakeasy-api/openapi v1.22.1-0.20260408022107-7a9aee7c092c
 	github.com/stretchr/testify v1.11.1
-	gopkg.in/yaml.v3 v3.0.1
+	go.yaml.in/yaml/v3 v3.0.4
 )
 
 require (
@@ -23,4 +23,5 @@ require (
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.36.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/openapi/linter/customrules/go.sum
+++ b/openapi/linter/customrules/go.sum
@@ -27,6 +27,8 @@ github.com/speakeasy-api/jsonpath v0.6.3 h1:c+QPwzAOdrWvzycuc9HFsIZcxKIaWcNpC+xh
 github.com/speakeasy-api/jsonpath v0.6.3/go.mod h1:2cXloNuQ+RSXi5HTRaeBh7JEmjRXTiaKpFTdZiL7URI=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
 golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/openapi/linter/customrules/runtime.go
+++ b/openapi/linter/customrules/runtime.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/dop251/goja"
 	"github.com/speakeasy-api/openapi/validation"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // Runtime wraps a goja JavaScript runtime with custom rule support.

--- a/openapi/linter/linter_test.go
+++ b/openapi/linter/linter_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/speakeasy-api/openapi/validation"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 type mockVirtualFS struct {

--- a/openapi/linter/rules/description_duplication.go
+++ b/openapi/linter/rules/description_duplication.go
@@ -8,7 +8,7 @@ import (
 	"github.com/speakeasy-api/openapi/openapi"
 	"github.com/speakeasy-api/openapi/validation"
 	"github.com/speakeasy-api/openapi/yml"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 const RuleStyleDescriptionDuplication = "style-description-duplication"

--- a/openapi/linter/rules/duplicated_entry_in_enum.go
+++ b/openapi/linter/rules/duplicated_entry_in_enum.go
@@ -7,7 +7,7 @@ import (
 	"github.com/speakeasy-api/openapi/linter"
 	"github.com/speakeasy-api/openapi/openapi"
 	"github.com/speakeasy-api/openapi/validation"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 const RuleSemanticDuplicatedEnum = "semantic-duplicated-enum"

--- a/openapi/linter/rules/fix_helpers.go
+++ b/openapi/linter/rules/fix_helpers.go
@@ -9,7 +9,7 @@ import (
 	"github.com/speakeasy-api/openapi/pointer"
 	"github.com/speakeasy-api/openapi/validation"
 	"github.com/speakeasy-api/openapi/yml"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // addErrorResponseFix adds a skeleton error response to an operation's responses node.

--- a/openapi/linter/rules/fix_helpers_test.go
+++ b/openapi/linter/rules/fix_helpers_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/speakeasy-api/openapi/yml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // ============================================================

--- a/openapi/linter/rules/fix_integration_test.go
+++ b/openapi/linter/rules/fix_integration_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/speakeasy-api/openapi/validation"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // These integration tests verify that fixes actually resolve the violations

--- a/openapi/linter/rules/host_trailing_slash.go
+++ b/openapi/linter/rules/host_trailing_slash.go
@@ -8,7 +8,7 @@ import (
 	"github.com/speakeasy-api/openapi/linter"
 	"github.com/speakeasy-api/openapi/openapi"
 	"github.com/speakeasy-api/openapi/validation"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 const RuleStyleOAS3HostTrailingSlash = "style-oas3-host-trailing-slash"

--- a/openapi/linter/rules/markdown_descriptions.go
+++ b/openapi/linter/rules/markdown_descriptions.go
@@ -1,7 +1,7 @@
 package rules
 
 import (
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // GetFieldValueNode gets the YAML value node for a specific field from any object with a GetCore() method.

--- a/openapi/linter/rules/oas3_no_nullable.go
+++ b/openapi/linter/rules/oas3_no_nullable.go
@@ -8,7 +8,7 @@ import (
 	"github.com/speakeasy-api/openapi/openapi"
 	"github.com/speakeasy-api/openapi/validation"
 	"github.com/speakeasy-api/openapi/yml"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 const RuleOAS3NoNullable = "oas3-no-nullable"

--- a/openapi/linter/rules/oas_schema_check.go
+++ b/openapi/linter/rules/oas_schema_check.go
@@ -11,7 +11,7 @@ import (
 	"github.com/speakeasy-api/openapi/linter"
 	"github.com/speakeasy-api/openapi/openapi"
 	"github.com/speakeasy-api/openapi/validation"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 const RuleOasSchemaCheck = "oas-schema-check"

--- a/openapi/linter/rules/operation_success_response.go
+++ b/openapi/linter/rules/operation_success_response.go
@@ -9,7 +9,7 @@ import (
 	"github.com/speakeasy-api/openapi/linter"
 	"github.com/speakeasy-api/openapi/openapi"
 	"github.com/speakeasy-api/openapi/validation"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 const RuleStyleOperationSuccessResponse = "style-operation-success-response"

--- a/openapi/linter/rules/owasp_jwt_best_practices.go
+++ b/openapi/linter/rules/owasp_jwt_best_practices.go
@@ -9,7 +9,7 @@ import (
 	"github.com/speakeasy-api/openapi/openapi"
 	"github.com/speakeasy-api/openapi/validation"
 	"github.com/speakeasy-api/openapi/yml"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 const RuleOwaspJWTBestPractices = "owasp-jwt-best-practices"

--- a/openapi/linter/rules/owasp_no_additional_properties.go
+++ b/openapi/linter/rules/owasp_no_additional_properties.go
@@ -8,7 +8,7 @@ import (
 	"github.com/speakeasy-api/openapi/openapi"
 	"github.com/speakeasy-api/openapi/validation"
 	"github.com/speakeasy-api/openapi/yml"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 const RuleOwaspNoAdditionalProperties = "owasp-no-additional-properties"

--- a/openapi/linter/rules/owasp_security_hosts_https_oas3.go
+++ b/openapi/linter/rules/owasp_security_hosts_https_oas3.go
@@ -9,7 +9,7 @@ import (
 	"github.com/speakeasy-api/openapi/openapi"
 	"github.com/speakeasy-api/openapi/validation"
 	"github.com/speakeasy-api/openapi/yml"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 const RuleOwaspSecurityHostsHttpsOAS3 = "owasp-security-hosts-https-oas3"

--- a/openapi/linter/rules/path_trailing_slash.go
+++ b/openapi/linter/rules/path_trailing_slash.go
@@ -8,7 +8,7 @@ import (
 	"github.com/speakeasy-api/openapi/linter"
 	"github.com/speakeasy-api/openapi/openapi"
 	"github.com/speakeasy-api/openapi/validation"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 const RuleStylePathTrailingSlash = "style-path-trailing-slash"

--- a/openapi/linter/rules/rule_fixes_test.go
+++ b/openapi/linter/rules/rule_fixes_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/speakeasy-api/openapi/yml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // ============================================================

--- a/openapi/linter/rules/tags_alphabetical.go
+++ b/openapi/linter/rules/tags_alphabetical.go
@@ -10,7 +10,7 @@ import (
 	"github.com/speakeasy-api/openapi/openapi"
 	"github.com/speakeasy-api/openapi/validation"
 	"github.com/speakeasy-api/openapi/yml"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 const RuleStyleTagsAlphabetical = "style-tags-alphabetical"

--- a/openapi/linter/rules/typed_enum.go
+++ b/openapi/linter/rules/typed_enum.go
@@ -10,7 +10,7 @@ import (
 	"github.com/speakeasy-api/openapi/linter"
 	"github.com/speakeasy-api/openapi/openapi"
 	"github.com/speakeasy-api/openapi/validation"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 const RuleSemanticTypedEnum = "semantic-typed-enum"

--- a/openapi/linter/rules/unused_components.go
+++ b/openapi/linter/rules/unused_components.go
@@ -10,7 +10,7 @@ import (
 	"github.com/speakeasy-api/openapi/openapi"
 	"github.com/speakeasy-api/openapi/references"
 	"github.com/speakeasy-api/openapi/validation"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 const RuleSemanticUnusedComponent = "semantic-unused-component"

--- a/openapi/localize.go
+++ b/openapi/localize.go
@@ -14,7 +14,7 @@ import (
 	"github.com/speakeasy-api/openapi/references"
 	"github.com/speakeasy-api/openapi/sequencedmap"
 	"github.com/speakeasy-api/openapi/system"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // LocalizeNamingStrategy defines how external reference files should be named when localized.

--- a/openapi/openapi.go
+++ b/openapi/openapi.go
@@ -15,7 +15,7 @@ import (
 	"github.com/speakeasy-api/openapi/pointer"
 	"github.com/speakeasy-api/openapi/sequencedmap"
 	"github.com/speakeasy-api/openapi/validation"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // Version is the version of the OpenAPI Specification that this package conforms to.

--- a/openapi/reference.go
+++ b/openapi/reference.go
@@ -14,7 +14,7 @@ import (
 	"github.com/speakeasy-api/openapi/pointer"
 	"github.com/speakeasy-api/openapi/references"
 	"github.com/speakeasy-api/openapi/validation"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 type (

--- a/openapi/sanitize.go
+++ b/openapi/sanitize.go
@@ -11,7 +11,7 @@ import (
 	"github.com/speakeasy-api/openapi/extensions"
 	"github.com/speakeasy-api/openapi/jsonschema/oas3"
 	"github.com/speakeasy-api/openapi/marshaller"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // ExtensionFilter specifies patterns for filtering extensions using allowed and denied lists.

--- a/openapi/upgrade.go
+++ b/openapi/upgrade.go
@@ -10,7 +10,7 @@ import (
 	"github.com/speakeasy-api/openapi/jsonschema/oas3"
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/speakeasy-api/openapi/sequencedmap"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 type UpgradeOptions struct {

--- a/openapi/upgrade_test.go
+++ b/openapi/upgrade_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/speakeasy-api/openapi/openapi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestUpgrade_Success(t *testing.T) {

--- a/oq/format.go
+++ b/oq/format.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/speakeasy-api/openapi/graph"
 	"github.com/speakeasy-api/openapi/oq/expr"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // FormatTable formats a result as a simple table string.

--- a/overlay/README.md
+++ b/overlay/README.md
@@ -30,7 +30,7 @@
 - **Remove, Update, and Copy Actions**: Support for remove actions (pruning nodes), update actions (merging values), and copy actions (duplicating or moving nodes)
 - **Flexible Input/Output**: Works with both YAML and JSON formats
 - **Batch Operations**: Apply multiple modifications to large numbers of nodes in a single operation
-- **YAML v1.2 Support**: Uses [gopkg.in/yaml.v3](https://pkg.go.dev/gopkg.in/yaml.v3) for YAML v1.2 parsing (superset of JSON)
+- **YAML v1.2 Support**: Uses [go.yaml.in/yaml/v3](https://pkg.go.dev/go.yaml.in/yaml/v3) for YAML v1.2 parsing (superset of JSON)
 
 ## About OpenAPI Overlays
 

--- a/overlay/apply.go
+++ b/overlay/apply.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/speakeasy-api/jsonpath/pkg/jsonpath/config"
 	"github.com/speakeasy-api/jsonpath/pkg/jsonpath/token"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // ApplyTo will take an overlay and apply its changes to the given YAML

--- a/overlay/apply_test.go
+++ b/overlay/apply_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/speakeasy-api/openapi/overlay/loader"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // NodeMatchesFile is a test that marshals the YAML file from the given node,

--- a/overlay/compare.go
+++ b/overlay/compare.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // Compare compares input specifications from two files and returns an overlay

--- a/overlay/compare_test.go
+++ b/overlay/compare_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/speakeasy-api/openapi/overlay/loader"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestCompare(t *testing.T) {

--- a/overlay/format_test.go
+++ b/overlay/format_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/speakeasy-api/openapi/overlay"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestOverlay_Format_Success(t *testing.T) {

--- a/overlay/jsonpath.go
+++ b/overlay/jsonpath.go
@@ -7,7 +7,7 @@ import (
 	"github.com/speakeasy-api/jsonpath/pkg/jsonpath/config"
 	"github.com/speakeasy-api/openapi/internal/version"
 	"github.com/vmware-labs/yaml-jsonpath/pkg/yamlpath"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // Queryable is an interface for querying YAML nodes using JSONPath expressions.

--- a/overlay/loader/spec.go
+++ b/overlay/loader/spec.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	"github.com/speakeasy-api/openapi/overlay"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // GetOverlayExtendsPath returns the path to file if the extends URL is a file

--- a/overlay/loader/spec_test.go
+++ b/overlay/loader/spec_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/speakeasy-api/openapi/overlay"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // pathToFileURL converts a file path to a proper file:// URL

--- a/overlay/overlay_examples_test.go
+++ b/overlay/overlay_examples_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/speakeasy-api/openapi/overlay"
 	"github.com/speakeasy-api/openapi/overlay/loader"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // Example_applying demonstrates how to apply an overlay to an OpenAPI document.

--- a/overlay/parents.go
+++ b/overlay/parents.go
@@ -1,6 +1,6 @@
 package overlay
 
-import "gopkg.in/yaml.v3"
+import "go.yaml.in/yaml/v3"
 
 type parentIndex map[*yaml.Node]*yaml.Node
 

--- a/overlay/parse.go
+++ b/overlay/parse.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // ParseReader parses an overlay from the given reader.

--- a/overlay/schema.go
+++ b/overlay/schema.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 
 	"github.com/speakeasy-api/openapi/internal/version"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // Version constants for the Overlay specification

--- a/overlay/upgrade_test.go
+++ b/overlay/upgrade_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/speakeasy-api/openapi/overlay"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestUpgrade_Success(t *testing.T) {

--- a/overlay/utils.go
+++ b/overlay/utils.go
@@ -3,7 +3,7 @@ package overlay
 import (
 	"fmt"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func NewTargetSelector(path, method string) string {

--- a/overlay/utils_test.go
+++ b/overlay/utils_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/speakeasy-api/openapi/overlay"
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestNewTargetSelector_Success(t *testing.T) {

--- a/overlay/validate_test.go
+++ b/overlay/validate_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/speakeasy-api/openapi/overlay"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestOverlay_Validate(t *testing.T) {

--- a/references/resolution.go
+++ b/references/resolution.go
@@ -12,7 +12,7 @@ import (
 	"github.com/speakeasy-api/openapi/internal/utils"
 	"github.com/speakeasy-api/openapi/jsonpointer"
 	"github.com/speakeasy-api/openapi/system"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 type ResolutionTarget interface {

--- a/references/resolution_test.go
+++ b/references/resolution_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/speakeasy-api/openapi/marshaller/tests"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // MockResolutionTarget implements ResolutionTarget for testing

--- a/sequencedmap/map.go
+++ b/sequencedmap/map.go
@@ -15,7 +15,7 @@ import (
 	"github.com/speakeasy-api/openapi/internal/interfaces"
 	"github.com/speakeasy-api/openapi/internal/utils"
 	"github.com/speakeasy-api/openapi/yml"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // OrderType represents the different ways to order iteration through the map

--- a/sequencedmap/map_advanced_test.go
+++ b/sequencedmap/map_advanced_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestMap_NavigateWithKey_Success(t *testing.T) {

--- a/sequencedmap/yaml_unmarshal_test.go
+++ b/sequencedmap/yaml_unmarshal_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/speakeasy-api/openapi/sequencedmap"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestSequencedMap_Standard_Yaml_Unmarshal(t *testing.T) {

--- a/swagger/core/paths.go
+++ b/swagger/core/paths.go
@@ -4,7 +4,7 @@ import (
 	"github.com/speakeasy-api/openapi/extensions/core"
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/speakeasy-api/openapi/sequencedmap"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // Paths holds the relative paths to the individual endpoints.

--- a/swagger/core/paths_test.go
+++ b/swagger/core/paths_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func parseYAML(t *testing.T, yml string) *yaml.Node {

--- a/swagger/core/reference.go
+++ b/swagger/core/reference.go
@@ -10,7 +10,7 @@ import (
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/speakeasy-api/openapi/validation"
 	"github.com/speakeasy-api/openapi/yml"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // Reference represents either a reference to a component or an inline object.

--- a/swagger/core/reference_test.go
+++ b/swagger/core/reference_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestReference_Unmarshal_Success(t *testing.T) {

--- a/swagger/core/response.go
+++ b/swagger/core/response.go
@@ -6,7 +6,7 @@ import (
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/speakeasy-api/openapi/sequencedmap"
 	values "github.com/speakeasy-api/openapi/values/core"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // Responses is a container for the expected responses of an operation.

--- a/swagger/core/response_test.go
+++ b/swagger/core/response_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestNewResponses_Success(t *testing.T) {

--- a/swagger/roundtrip_test.go
+++ b/swagger/roundtrip_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/speakeasy-api/openapi/yml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 type roundTripTest struct {

--- a/validation/errors.go
+++ b/validation/errors.go
@@ -3,7 +3,7 @@ package validation
 import (
 	"fmt"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 type Severity string

--- a/validation/fix.go
+++ b/validation/fix.go
@@ -1,6 +1,6 @@
 package validation
 
-import "gopkg.in/yaml.v3"
+import "go.yaml.in/yaml/v3"
 
 // PromptType describes what kind of user input a fix needs.
 type PromptType int

--- a/validation/utils_test.go
+++ b/validation/utils_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // Test SortValidationErrors function

--- a/validation/validation_test.go
+++ b/validation/validation_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // Test the Error type methods

--- a/values/core/eithervalue.go
+++ b/values/core/eithervalue.go
@@ -10,7 +10,7 @@ import (
 	"github.com/speakeasy-api/openapi/internal/interfaces"
 	"github.com/speakeasy-api/openapi/marshaller"
 	"github.com/speakeasy-api/openapi/validation"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 type EitherValue[L any, R any] struct {

--- a/values/core/eithervalue_test.go
+++ b/values/core/eithervalue_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/speakeasy-api/openapi/validation"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 type TestEitherValue[L any, R any] struct {

--- a/values/core/value.go
+++ b/values/core/value.go
@@ -1,6 +1,6 @@
 package core
 
-import "gopkg.in/yaml.v3"
+import "go.yaml.in/yaml/v3"
 
 // Value represents a raw value in an OpenAPI or Arazzo document.
 type Value = *yaml.Node

--- a/values/value.go
+++ b/values/value.go
@@ -1,6 +1,6 @@
 package values
 
-import "gopkg.in/yaml.v3"
+import "go.yaml.in/yaml/v3"
 
 // Value represents a raw value in an OpenAPI or Arazzo document.
 type Value = *yaml.Node

--- a/yml/config.go
+++ b/yml/config.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"strconv"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 type contextKey string

--- a/yml/config_test.go
+++ b/yml/config_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/speakeasy-api/openapi/yml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestContextKey_String_Success(t *testing.T) {

--- a/yml/nodekind.go
+++ b/yml/nodekind.go
@@ -1,6 +1,6 @@
 package yml
 
-import "gopkg.in/yaml.v3"
+import "go.yaml.in/yaml/v3"
 
 // NodeKindToString returns a human-readable string representation of a yaml.Kind.
 // This helper function is useful for creating more user-friendly error messages

--- a/yml/nodekind_test.go
+++ b/yml/nodekind_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/speakeasy-api/openapi/yml"
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestNodeKindToString(t *testing.T) {

--- a/yml/walk.go
+++ b/yml/walk.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/speakeasy-api/openapi/errors"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 const (

--- a/yml/walk_test.go
+++ b/yml/walk_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/speakeasy-api/openapi/yml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestWalk_Success(t *testing.T) {

--- a/yml/yml.go
+++ b/yml/yml.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"strconv"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func CreateOrUpdateKeyNode(ctx context.Context, key string, keyNode *yaml.Node) *yaml.Node {

--- a/yml/yml_test.go
+++ b/yml/yml_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/speakeasy-api/openapi/yml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestCreateOrUpdateKeyNode_Success(t *testing.T) {


### PR DESCRIPTION
## Problem

`gopkg.in/yaml.v3` is unmaintained and flagged by security scanners (kubernetes-sigs/yaml#117). It is no longer receiving updates.

## Fix

Replace all usages across the codebase with `go.yaml.in/yaml/v3`, the canonical successor package maintained by the same upstream authors.

- All Go import paths updated via batch find+replace
- `go.mod` updated to `go.yaml.in/yaml/v3 v3.0.4`

The API is identical — no code logic changes, import path only.

Closes #201