### PR TITLE
fix: handle nil jsonpointer sources

### DIFF
--- a/jsonpointer/jsonpointer.go
+++ b/jsonpointer/jsonpointer.go
@@ -127,6 +127,9 @@ func getTarget(source any, currentPart navigationPart, stack []navigationPart, c
 	}
 
 	sourceType := reflect.TypeOf(source)
+	if sourceType == nil {
+		return nil, nil, ErrNotFound.Wrap(fmt.Errorf("source is nil at %s", currentPath))
+	}
 	sourceElemType := sourceType
 
 	if sourceType.Kind() == reflect.Ptr {

--- a/jsonpointer/jsonpointer_test.go
+++ b/jsonpointer/jsonpointer_test.go
@@ -368,6 +368,14 @@ func TestGetTarget_Error(t *testing.T) {
 			wantErr: errors.New("not found -- slice is nil at /0"),
 		},
 		{
+			name: "nil source",
+			args: args{
+				source:  nil,
+				pointer: JSONPointer("/key1"),
+			},
+			wantErr: errors.New("not found -- source is nil at /key1"),
+		},
+		{
 			name: "nil struct",
 			args: args{
 				source:  (*TestStruct)(nil),


### PR DESCRIPTION
## Summary
- return a not found error when jsonpointer navigation receives an untyped nil source
- add a regression test for nil source navigation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return a "not found" error when `jsonpointer` navigation receives a nil source, including the path in the message. Adds a regression test to cover nil source traversal.

<sup>Written for commit 062e985117bf7479aeb3c7a711fad7881a3cfa4f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/openapi/pull/213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

