### PR TITLE
feat(oq): add GCF as --format gcf output option

### DIFF
--- a/cmd/openapi/commands/openapi/README.md
+++ b/cmd/openapi/commands/openapi/README.md
@@ -1260,7 +1260,7 @@ openapi spec query --format json 'schemas | where(isComponent) | take(5)' ./spec
 
 | Flag       | Short | Description                                                     |
 | ---------- | ----- | --------------------------------------------------------------- |
-| `--format` |       | Output format: `table` (default), `json`, `markdown`, or `toon` |
+| `--format` |       | Output format: `table` (default), `json`, `markdown`, `toon`, or `gcf` |
 | `--file`   | `-f`  | Read query from file instead of argument                        |
 
 For the full query language reference, run `openapi spec query-reference`.

--- a/cmd/openapi/commands/openapi/query.go
+++ b/cmd/openapi/commands/openapi/query.go
@@ -36,7 +36,7 @@ Pipeline stages:
                group-by(field), group-by(field, name_field), length
   Variables:   let $var = expr
   Functions:   def name: body;  def name($p): body;  include "file.oq";
-  Output:      to-yaml, format(table|json|markdown|toon)
+  Output:      to-yaml, format(table|json|markdown|toon|gcf)
   Meta:        explain, fields
 
 Operators: ==, !=, >, <, >=, <=, and, or, not, // (or default), has(),

--- a/cmd/openapi/commands/openapi/query.go
+++ b/cmd/openapi/commands/openapi/query.go
@@ -60,7 +60,7 @@ var queryOutputFormat string
 var queryFromFile string
 
 func init() {
-	queryCmd.Flags().StringVar(&queryOutputFormat, "format", "table", "output format: table, json, markdown, or toon")
+	queryCmd.Flags().StringVar(&queryOutputFormat, "format", "table", "output format: table, json, markdown, toon, or gcf")
 	queryCmd.Flags().StringVarP(&queryFromFile, "file", "f", "", "read query from file instead of argument")
 
 	// Custom help template: Usage + Flags together, then Examples last
@@ -167,6 +167,8 @@ func queryOpenAPI(ctx context.Context, processor *OpenAPIProcessor, queryStr str
 		output = oq.FormatMarkdown(result, g)
 	case "toon":
 		output = oq.FormatToon(result, g)
+	case "gcf":
+		output = oq.FormatGCF(result, g)
 	default:
 		output = oq.FormatTable(result, g)
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/speakeasy-api/openapi
 go 1.26.1
 
 require (
+	github.com/blackwell-systems/gcf-go v1.2.1
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/speakeasy-api/jsonpath v0.6.3
 	github.com/stretchr/testify v1.11.1
@@ -13,7 +14,6 @@ require (
 )
 
 require (
-	github.com/blackwell-systems/gcf-go v1.2.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dlclark/regexp2 v1.11.4 // indirect
 	github.com/dprotaso/go-yit v0.0.0-20191028211022-135eb7262960 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/speakeasy-api/openapi
 
-go 1.26.1
+go 1.25.0
 
 require (
-	github.com/blackwell-systems/gcf-go v1.2.1
+	github.com/blackwell-systems/gcf-go v1.2.2
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/speakeasy-api/jsonpath v0.6.3
 	github.com/stretchr/testify v1.11.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/speakeasy-api/openapi
 
-go 1.25.0
+go 1.26.1
 
 require (
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
@@ -13,6 +13,7 @@ require (
 )
 
 require (
+	github.com/blackwell-systems/gcf-go v1.2.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dlclark/regexp2 v1.11.4 // indirect
 	github.com/dprotaso/go-yit v0.0.0-20191028211022-135eb7262960 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/blackwell-systems/gcf-go v1.2.1 h1:NsoGZKQxT8O3WKl+QssiFdvhPM0cCCyJ3a3x1H5fGDI=
+github.com/blackwell-systems/gcf-go v1.2.1/go.mod h1:sROSBELq+iEDf3pD1x4AcY2QccFd1KHsGajFzjVlCNc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/blackwell-systems/gcf-go v1.2.1 h1:NsoGZKQxT8O3WKl+QssiFdvhPM0cCCyJ3a3x1H5fGDI=
-github.com/blackwell-systems/gcf-go v1.2.1/go.mod h1:sROSBELq+iEDf3pD1x4AcY2QccFd1KHsGajFzjVlCNc=
+github.com/blackwell-systems/gcf-go v1.2.2 h1:oPc9VbC5DDMPek/RMWO3zVcImVr3QTOcCIgBOLcjNRk=
+github.com/blackwell-systems/gcf-go v1.2.2/go.mod h1:E4fW1kxdrIoWxlI4iwZL8mh7BvdLTkE88NyijtGGcZc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/oq/README.md
+++ b/oq/README.md
@@ -113,7 +113,7 @@ Navigate into the internal structure of operations. These stages produce new row
 |-------|-------------|
 | `explain` | Print query plan |
 | `fields` | List available fields |
-| `format(fmt)` | Set output format (table/json/markdown/toon) |
+| `format(fmt)` | Set output format (table/json/markdown/toon/gcf) |
 | `to-yaml` | Output raw YAML nodes from underlying spec objects |
 
 The `to-yaml` stage uses `path` (JSON pointer) as the wrapper key for each emitted node, giving full attribution to the source location in the spec.
@@ -349,6 +349,7 @@ openapi spec query 'schemas | take(5) | format(markdown)' spec.yaml
 | `json` | JSON array |
 | `markdown` | Markdown table |
 | `toon` | [TOON](https://github.com/toon-format/toon) tabular format |
+| `gcf` | [GCF](https://gcformat.com) pipe-delimited format with inline schemas |
 
 ## Examples
 

--- a/oq/format.go
+++ b/oq/format.go
@@ -223,8 +223,7 @@ func FormatToon(result *Result, g *graph.SchemaGraph) string {
 }
 
 // FormatGCF formats a result using GCF (Graph Compact Format).
-// GCF uses positional pipe-delimited rows with inline schemas, achieving
-// higher LLM comprehension accuracy than TOON or JSON (90.7% vs 68.5% vs 53.6%).
+// GCF uses positional pipe-delimited rows with inline schemas.
 // See https://gcformat.com
 func FormatGCF(result *Result, g *graph.SchemaGraph) string {
 	if result.Explain != "" {

--- a/oq/format.go
+++ b/oq/format.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 
+	gcf "github.com/blackwell-systems/gcf-go"
 	"github.com/speakeasy-api/openapi/graph"
 	"github.com/speakeasy-api/openapi/oq/expr"
 	"gopkg.in/yaml.v3"
@@ -219,6 +220,54 @@ func FormatToon(result *Result, g *graph.SchemaGraph) string {
 	}
 
 	return sb.String()
+}
+
+// FormatGCF formats a result using GCF (Graph Compact Format).
+// GCF uses positional pipe-delimited rows with inline schemas, achieving
+// higher LLM comprehension accuracy than TOON or JSON (90.7% vs 68.5% vs 53.6%).
+// See https://gcformat.com
+func FormatGCF(result *Result, g *graph.SchemaGraph) string {
+	if result.Explain != "" {
+		return result.Explain
+	}
+
+	if result.IsCount {
+		return gcf.EncodeGeneric(map[string]interface{}{"count": result.Count})
+	}
+
+	syncGroupsFromRows(result)
+
+	if len(result.Rows) == 0 {
+		return gcf.EncodeGeneric([]interface{}{})
+	}
+
+	fields := result.Fields
+	if len(fields) == 0 {
+		fields = resolveDefaultFields(result.Rows)
+	}
+
+	rows := make([]interface{}, 0, len(result.Rows))
+	for _, row := range result.Rows {
+		m := make(map[string]interface{}, len(fields))
+		for _, f := range fields {
+			v := fieldValue(row, f, g)
+			switch v.Kind {
+			case expr.KindString:
+				m[f] = v.Str
+			case expr.KindInt:
+				m[f] = v.Int
+			case expr.KindBool:
+				m[f] = v.Bool
+			case expr.KindArray:
+				m[f] = v.Arr
+			default:
+				m[f] = nil
+			}
+		}
+		rows = append(rows, m)
+	}
+
+	return gcf.EncodeGeneric(rows)
 }
 
 // FormatYAML formats results as raw YAML from the underlying schema/operation objects.

--- a/oq/oq.go
+++ b/oq/oq.go
@@ -85,7 +85,7 @@ type Result struct {
 	Count      int
 	Groups     []GroupResult
 	Explain    string // human-readable pipeline explanation
-	FormatHint string // format preference from format stage (table, json, markdown, toon)
+	FormatHint string // format preference from format stage (table, json, markdown, toon, gcf)
 	EmitYAML   bool   // emit raw YAML nodes instead of formatted output
 }
 

--- a/oq/oq_test.go
+++ b/oq/oq_test.go
@@ -1412,6 +1412,98 @@ func TestFormatToon_Explain(t *testing.T) {
 	assert.Contains(t, toon, "Source: schemas", "toon should render explain output")
 }
 
+func TestFormatGCF_Success(t *testing.T) {
+	t.Parallel()
+	g := loadTestGraph(t)
+
+	result, err := oq.Execute("schemas | where(isComponent) | take(3) | select name, type", g)
+	require.NoError(t, err)
+
+	out := oq.FormatGCF(result, g)
+	assert.Contains(t, out, "GCF profile=generic", "gcf should have profile header")
+	assert.Contains(t, out, "{name,type}", "gcf should declare field names")
+	assert.Contains(t, out, "object", "gcf should include object type value")
+}
+
+func TestFormatGCF_Count_Success(t *testing.T) {
+	t.Parallel()
+	g := loadTestGraph(t)
+
+	result, err := oq.Execute("schemas | length", g)
+	require.NoError(t, err)
+
+	out := oq.FormatGCF(result, g)
+	assert.Contains(t, out, "count=", "gcf count should use key=value format")
+}
+
+func TestFormatGCF_Groups_Success(t *testing.T) {
+	t.Parallel()
+	g := loadTestGraph(t)
+
+	result, err := oq.Execute("schemas | where(isComponent) | group-by(type)", g)
+	require.NoError(t, err)
+
+	out := oq.FormatGCF(result, g)
+	assert.Contains(t, out, "GCF profile=generic", "gcf should have profile header")
+	assert.Contains(t, out, "{count,key,names}", "gcf should declare group fields")
+}
+
+func TestFormatGCF_Empty_Success(t *testing.T) {
+	t.Parallel()
+	g := loadTestGraph(t)
+
+	result, err := oq.Execute(`schemas | where(isComponent) | where(name == "NonExistent")`, g)
+	require.NoError(t, err)
+
+	out := oq.FormatGCF(result, g)
+	assert.Contains(t, out, "GCF profile=generic", "empty gcf should still have profile header")
+}
+
+func TestFormatGCF_BoolAndIntFields(t *testing.T) {
+	t.Parallel()
+	g := loadTestGraph(t)
+
+	result, err := oq.Execute("schemas | where(isComponent) | take(1) | select name, depth, isComponent", g)
+	require.NoError(t, err)
+
+	out := oq.FormatGCF(result, g)
+	assert.NotEmpty(t, out, "gcf output should not be empty")
+	assert.Contains(t, out, "GCF profile=generic", "gcf should have profile header")
+}
+
+func TestFormatGCF_SpecialChars(t *testing.T) {
+	t.Parallel()
+	g := loadTestGraph(t)
+
+	result, err := oq.Execute("schemas | where(isComponent) | take(1) | select name, hash, location", g)
+	require.NoError(t, err)
+
+	out := oq.FormatGCF(result, g)
+	assert.Contains(t, out, "GCF profile=generic", "gcf should have profile header")
+	assert.Contains(t, out, "{hash,location,name}", "gcf should declare fields with special-char values")
+}
+
+func TestFormatGCF_Explain(t *testing.T) {
+	t.Parallel()
+	g := loadTestGraph(t)
+
+	result, err := oq.Execute("schemas | where(depth > 0) | explain", g)
+	require.NoError(t, err)
+
+	out := oq.FormatGCF(result, g)
+	assert.Contains(t, out, "Source: schemas", "gcf should render explain output as-is")
+}
+
+func TestFormatGCF_InlinePipeline(t *testing.T) {
+	t.Parallel()
+	g := loadTestGraph(t)
+
+	result, err := oq.Execute("schemas | where(isComponent) | take(3) | format(gcf)", g)
+	require.NoError(t, err)
+
+	assert.Equal(t, "gcf", result.FormatHint, "format(gcf) should set FormatHint")
+}
+
 func TestFormatMarkdown_Explain(t *testing.T) {
 	t.Parallel()
 	g := loadTestGraph(t)

--- a/oq/parse.go
+++ b/oq/parse.go
@@ -322,8 +322,8 @@ func parseStage(s string) (Stage, error) {
 
 	case "format":
 		f := strings.TrimSpace(args)
-		if f != "table" && f != "json" && f != "markdown" && f != "toon" {
-			return Stage{}, fmt.Errorf("format must be table, json, markdown, or toon, got %q", f)
+		if f != "table" && f != "json" && f != "markdown" && f != "toon" && f != "gcf" {
+			return Stage{}, fmt.Errorf("format must be table, json, markdown, toon, or gcf, got %q", f)
 		}
 		return Stage{Kind: StageFormat, Format: f}, nil
 


### PR DESCRIPTION
## Summary

Add `--format gcf` as a new output format option for the `oq` query command, alongside existing table, json, markdown, and toon formats. Also available as an inline pipeline stage: `format(gcf)`.

## Why

### Your TOON encoder has a silent data corruption bug

The hand-rolled `toonValue` function in `format.go` encodes arrays by joining elements with semicolons:

```go
case expr.KindArray:
    return toonEscape(strings.Join(v.Arr, ";"))
```

If any array element contains a semicolon, the data silently corrupts on decode. A 2-element array becomes 4 elements:

```
Input:   ["v1;deprecated", "v2;current"]  (2 elements)
Encoded: v1;deprecated;v2;current
Decoded: ["v1", "deprecated", "v2", "current"]  (4 elements)
```

OpenAPI schemas have array fields (scopes, tags, enum values) where this can occur. GCF handles arrays natively with proper quoting, no lossy joins.

### LLM comprehension

When `oq` output is consumed by LLMs (agent workflows, AI-assisted API exploration), format comprehension accuracy matters:

- **GCF: 100%** on general structured data across every frontier model (Claude, GPT-5.5, Gemini)
- **GCF: 90.7%** on adversarial/complex payloads (500 symbols, 200 edges)
- **TOON: 68.5%** on the same adversarial data
- **JSON: 53.6%**

1,700+ evaluations across 10 models from 3 providers. No model has been trained on GCF.

Full eval data: [GCF benchmarks](https://gcformat.com/guide/benchmarks)

### Data integrity

GCF is verified lossless across **43 billion+** round-trips in 5 formats (JSON, YAML, TOML, CSV, MessagePack) and 6 language implementations. Zero failures.

Unlike the hand-rolled TOON encoder, GCF has a formal spec, a decoder, conformance fixtures, and fuzz testing backing every claimed number.

Full verification data: [Lossless verification](https://gcformat.com/guide/lossless-verification)

### Zero dependencies

`gcf-go` has zero runtime dependencies beyond the Go standard library, same as the rest of the `oq` package.

## Changes

| File | Change |
|------|--------|
| `oq/format.go` | Add `FormatGCF` function, import `gcf-go` |
| `oq/parse.go` | Accept `"gcf"` in inline `format()` stage |
| `oq/oq.go` | Update `FormatHint` comment |
| `cmd/openapi/commands/openapi/query.go` | Add `case "gcf"`, update `--format` help text |
| `go.mod` / `go.sum` | Add `github.com/blackwell-systems/gcf-go` |

## Usage

```bash
openapi query petstore.yaml "schemas | where(isComponent) | take(5)" --format gcf
openapi query petstore.yaml "schemas | where(isComponent) | take(5) | format(gcf)"
```

## Links

- GCF spec and docs: https://gcformat.com
- GCF Go SDK: https://pkg.go.dev/github.com/blackwell-systems/gcf-go
- SDKs in 6 languages: https://gcformat.com/guide/getting-started
- Eval results: https://gcformat.com/guide/eval-results
- Lossless verification: https://gcformat.com/guide/lossless-verification

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds GCF as an output format to the `oq` query command and pipeline for lossless arrays and clearer LLM consumption. Use --format gcf or format(gcf).

- New Features
  - Add `--format gcf` and pipeline stage `format(gcf)` to `openapi query`.
  - Implement `FormatGCF` using `github.com/blackwell-systems/gcf-go` v1.2.2; preserves types and emits native arrays.
  - Update help text, parser validation, and docs to include `gcf`.
  - Add tests for GCF output (count, groups, explain, special chars, inline stage).

<sup>Written for commit b882efa556bba5f55568a89137ed4920b2d498b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/openapi/pull/216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

