### PR TITLE
fix: quote TOON array elements containing semicolons

### DIFF
--- a/oq/format.go
+++ b/oq/format.go
@@ -350,10 +350,22 @@ func toonValue(v expr.Value) string {
 	case expr.KindBool:
 		return strconv.FormatBool(v.Bool)
 	case expr.KindArray:
-		return toonEscape(strings.Join(v.Arr, ";"))
+		return toonArrayValue(v.Arr)
 	default:
 		return "null"
 	}
+}
+
+func toonArrayValue(values []string) string {
+	parts := make([]string, len(values))
+	for i, value := range values {
+		if strings.Contains(value, ";") {
+			parts[i] = toonQuote(value)
+			continue
+		}
+		parts[i] = toonEscape(value)
+	}
+	return strings.Join(parts, ";")
 }
 
 // toonEscape quotes a string if it needs escaping for TOON format.
@@ -387,7 +399,10 @@ func toonEscape(s string) string {
 	if !needsQuote {
 		return s
 	}
-	// Quote with escaping
+	return toonQuote(s)
+}
+
+func toonQuote(s string) string {
 	var sb strings.Builder
 	sb.WriteByte('"')
 	for _, ch := range s {

--- a/oq/format_test.go
+++ b/oq/format_test.go
@@ -1,0 +1,18 @@
+package oq
+
+import (
+	"testing"
+
+	"github.com/speakeasy-api/openapi/oq/expr"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestToonValue_ArrayEscapesSemicolonElements(t *testing.T) {
+	t.Parallel()
+
+	value := expr.ArrayVal([]string{"v1;deprecated", "v2;current"})
+
+	encoded := toonValue(value)
+
+	assert.Equal(t, `"v1;deprecated";"v2;current"`, encoded, "array elements containing the delimiter should be quoted individually")
+}


### PR DESCRIPTION
## Why

TOON array output uses `;` as the element delimiter, but array elements containing `;` were previously joined without quoting the element first. That made values like `v1;deprecated` indistinguishable from multiple array entries when decoded.

## What changed

- Encode TOON array elements individually before joining them with `;`.
- Quote array elements that contain the `;` delimiter while preserving existing escaping behavior for other values.
- Add a regression test covering semicolon-containing TOON array elements.

## Review notes

- The behavior change is limited to TOON array formatting in `oq/format.go`.
- Scalar TOON string formatting is unchanged; the new delimiter-specific quoting only applies when encoding array elements.

## Testing

- `mise test -run TestToonValue_ArrayEscapesSemicolonElements ./oq` — passed.
- `mise test ./oq` — passed.
- `mise ci` — passed locally.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix TOON array encoding by quoting elements that contain semicolons, so values like v1;deprecated are not split during decoding. This removes ambiguity when decoding TOON arrays.

- **Bug Fixes**
  - Encode TOON array elements individually, then join with `;`.
  - Keep scalar TOON string formatting unchanged.
  - Add a regression test for semicolon-containing array elements.

<sup>Written for commit d0796891652fec69515b86e930ea558ed77f03ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/openapi/pull/217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

