### PR TITLE
feat: add deterministic JSON formatter

### DIFF
--- a/sortfmt/edge_cases_test.go
+++ b/sortfmt/edge_cases_test.go
@@ -1,0 +1,523 @@
+package sortfmt
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestFormat_ReadError(t *testing.T) {
+	t.Parallel()
+
+	var output bytes.Buffer
+	err := Format(failingReader{}, &output)
+	require.ErrorContains(t, err, "read document")
+	require.ErrorIs(t, err, errTestIO)
+}
+
+func TestParseJSON_RejectsTrailingValues(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		contains string
+	}{
+		{name: "second value", input: `{} []`, contains: "multiple JSON values"},
+		{name: "invalid trailing data", input: `{} invalid`, contains: "invalid character"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := parseJSON([]byte(tt.input))
+			require.ErrorContains(t, err, tt.contains)
+		})
+	}
+}
+
+func TestFormat_UnicodeEscapeBoundaries(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		input         string
+		expected      string
+		errorContains string
+	}{
+		{
+			name:     "ordinary escape",
+			input:    `{"a":"\u0061"}`,
+			expected: "{\n  \"a\": \"a\"\n}\n",
+		},
+		{
+			name:          "high surrogate without pair",
+			input:         `{"a":"\ud83dX"}`,
+			errorContains: "lone surrogate escape",
+		},
+		{
+			name:          "high surrogate followed by non-low escape",
+			input:         `{"a":"\ud83d\u0041"}`,
+			errorContains: "lone surrogate escape",
+		},
+		{
+			name:          "escaped backslash breaks pair",
+			input:         `{"a":"\ud83d\\ude00"}`,
+			errorContains: "lone surrogate escape",
+		},
+		{
+			name:          "surrogates cannot pair across strings",
+			input:         `{"a":"\ud83d","b":"\ude00"}`,
+			errorContains: "lone surrogate escape",
+		},
+		{
+			name:          "reported byte offset",
+			input:         `{"a":"\ud83d"}`,
+			errorContains: "at byte 6",
+		},
+		{
+			name:     "escaped backslash before valid pair",
+			input:    `{"a":"\\\ud83d\ude00"}`,
+			expected: "{\n  \"a\": \"\\\\\\ud83d\\ude00\"\n}\n",
+		},
+		{
+			name:     "escaped quote",
+			input:    `{"a":"quote: \""}`,
+			expected: "{\n  \"a\": \"quote: \\\"\"\n}\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var output bytes.Buffer
+			err := Format(strings.NewReader(tt.input), &output)
+			if tt.errorContains != "" {
+				require.ErrorContains(t, err, tt.errorContains)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, output.String())
+		})
+	}
+}
+
+func FuzzFormatRoundTrip(f *testing.F) {
+	for _, seed := range []string{`\`, `\\u`, `"\ud83d`, "\u2028", "😀"} {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, value string) {
+		input, err := json.Marshal(map[string]string{"k": value})
+		require.NoError(t, err)
+
+		var normalized map[string]string
+		require.NoError(t, json.Unmarshal(input, &normalized))
+
+		var formatted bytes.Buffer
+		require.NoError(t, Format(bytes.NewReader(input), &formatted))
+
+		var decoded map[string]string
+		require.NoError(t, json.Unmarshal(formatted.Bytes(), &decoded))
+		assert.Equal(t, normalized, decoded, "formatting should preserve JSON string semantics")
+
+		var idempotent bytes.Buffer
+		require.NoError(t, Format(bytes.NewReader(formatted.Bytes()), &idempotent))
+		assert.Equal(t, formatted.Bytes(), idempotent.Bytes(), "formatted output should be idempotent")
+	})
+}
+
+func TestParseHexCodeUnit(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		start    int
+		expected uint16
+		ok       bool
+	}{
+		{name: "decimal", input: "0031", expected: 0x31, ok: true},
+		{name: "lowercase", input: "d83d", expected: 0xd83d, ok: true},
+		{name: "uppercase", input: "DE00", expected: 0xde00, ok: true},
+		{name: "offset", input: "xx0041yy", start: 2, expected: 0x41, ok: true},
+		{name: "too short", input: "123", ok: false},
+		{name: "invalid digit", input: "12g4", ok: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual, ok := parseHexCodeUnit([]byte(tt.input), tt.start)
+			assert.Equal(t, tt.ok, ok)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestJSONValueToNode_UnsupportedNestedValues(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		value any
+	}{
+		{name: "root", value: make(chan struct{})},
+		{name: "mapping child", value: map[string]any{"bad": make(chan struct{})}},
+		{name: "sequence child", value: []any{make(chan struct{})}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := jsonValueToNode(tt.value)
+			require.ErrorContains(t, err, "unsupported JSON value type")
+		})
+	}
+}
+
+func TestSort_RejectsMalformedNodes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		node     *yaml.Node
+		contains string
+	}{
+		{
+			name:     "empty document",
+			node:     &yaml.Node{Kind: yaml.DocumentNode},
+			contains: "document must contain exactly one value",
+		},
+		{
+			name:     "unsupported node",
+			node:     &yaml.Node{Kind: yaml.AliasNode},
+			contains: "unsupported YAML node kind",
+		},
+		{
+			name: "unmatched mapping key",
+			node: &yaml.Node{
+				Kind:    yaml.MappingNode,
+				Content: []*yaml.Node{stringNode("key")},
+			},
+			contains: "mapping has an unmatched key",
+		},
+		{
+			name: "non-string mapping key",
+			node: &yaml.Node{
+				Kind:    yaml.MappingNode,
+				Content: []*yaml.Node{intNode("1"), stringNode("value")},
+			},
+			contains: "JSON object key must be a string",
+		},
+		{
+			name: "unsupported mapping value",
+			node: &yaml.Node{
+				Kind:    yaml.MappingNode,
+				Content: []*yaml.Node{stringNode("key"), {Kind: yaml.AliasNode}},
+			},
+			contains: "unsupported YAML node kind",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.ErrorContains(t, Sort(tt.node), tt.contains)
+		})
+	}
+}
+
+func TestSort_PreservesRootSequenceOrder(t *testing.T) {
+	t.Parallel()
+
+	node := &yaml.Node{
+		Kind:    yaml.SequenceNode,
+		Content: []*yaml.Node{stringNode("z"), stringNode("a")},
+	}
+	require.NoError(t, Sort(node))
+	assert.Equal(t, "z", node.Content[0].Value)
+	assert.Equal(t, "a", node.Content[1].Value)
+}
+
+func TestSort_PreservesMappingWhenNestedSortFails(t *testing.T) {
+	t.Parallel()
+
+	document, err := parseJSON([]byte(`{"c":3,"b":{"oneOf":[{"type":"string"},{"type":["string","null"]}]},"a":1}`))
+	require.NoError(t, err)
+	root := document.Content[0]
+	originalContent := append([]*yaml.Node(nil), root.Content...)
+
+	err = Sort(document)
+	require.ErrorContains(t, err, "sort oneOf items")
+	assert.Equal(t, originalContent, root.Content, "a nested error must not truncate or reorder the containing mapping")
+}
+
+func TestFormat_ParentSpecificKeyOrdering(t *testing.T) {
+	t.Parallel()
+
+	input := `{"paths":{"/a":{"get":{},"description":"","parameters":[]}},"properties":{"type":{},"name":{},"a":{}}}`
+	expected := `{
+  "paths": {
+    "/a": {
+      "description": "",
+      "parameters": [],
+      "get": {}
+    }
+  },
+  "properties": {
+    "a": {},
+    "name": {},
+    "type": {}
+  }
+}
+`
+
+	var output bytes.Buffer
+	require.NoError(t, Format(strings.NewReader(input), &output))
+	assert.Equal(t, expected, output.String())
+}
+
+func TestPythonSortKey_ListOrderingAndErrors(t *testing.T) {
+	t.Parallel()
+
+	less, err := (pythonSortKey{kind: pythonSortKeyStringList, stringList: []string{"a"}}).less(
+		pythonSortKey{kind: pythonSortKeyStringList, stringList: []string{"a", "b"}},
+	)
+	require.NoError(t, err)
+	assert.True(t, less, "a shorter equal-prefix list should sort first")
+
+	_, err = (pythonSortKey{kind: pythonSortKeyKind(99)}).less(pythonSortKey{kind: pythonSortKeyKind(99)})
+	require.ErrorContains(t, err, "unsupported selected-list sort key kind")
+}
+
+func TestListSortKey_RejectsInvalidCandidates(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		node     *yaml.Node
+		contains string
+	}{
+		{
+			name:     "non-string scalar key",
+			node:     mappingNode("name", intNode("1")),
+			contains: "name sort key must be a string or string array",
+		},
+		{
+			name:     "non-string array item",
+			node:     mappingNode("type", sequenceNode(stringNode("string"), intNode("1"))),
+			contains: "type array sort key item 1 must be a string",
+		},
+		{
+			name:     "invalid mapping fallback",
+			node:     mappingNode("other", &yaml.Node{Kind: yaml.AliasNode}),
+			contains: "unsupported YAML node kind",
+		},
+		{
+			name:     "invalid scalar fallback",
+			node:     &yaml.Node{Kind: yaml.AliasNode},
+			contains: "unsupported YAML node kind",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := listSortKey(tt.node)
+			require.ErrorContains(t, err, tt.contains)
+		})
+	}
+}
+
+func TestPythonRepr_CompositeAndErrors(t *testing.T) {
+	t.Parallel()
+
+	composite := mappingNode("key", sequenceNode(
+		stringNode("value"),
+		boolNode("true"),
+		intNode("42"),
+		floatNode("1.5"),
+		nullNode(),
+	))
+	actual, err := pythonRepr(composite)
+	require.NoError(t, err)
+	assert.Equal(t, `{'key': ['value', True, 42, 1.5, None]}`, actual)
+
+	tests := []struct {
+		name     string
+		node     *yaml.Node
+		contains string
+	}{
+		{name: "invalid mapping child", node: mappingNode("key", boolNode("yes")), contains: "invalid boolean value"},
+		{name: "invalid sequence child", node: sequenceNode(boolNode("yes")), contains: "invalid boolean value"},
+		{name: "invalid boolean", node: boolNode("yes"), contains: "invalid boolean value"},
+		{name: "unsupported scalar", node: &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!timestamp"}, contains: "unsupported scalar tag"},
+		{name: "unsupported node", node: &yaml.Node{Kind: yaml.AliasNode}, contains: "unsupported YAML node kind"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := pythonRepr(tt.node)
+			require.ErrorContains(t, err, tt.contains)
+		})
+	}
+}
+
+func TestQuotePythonString_EscapesLikePythonRepr(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{name: "prefer double quote", input: "it's", expected: `"it's"`},
+		{name: "escape selected quote", input: `both ' and "`, expected: `'both \' and "'`},
+		{name: "common escapes", input: "\\\n\r\t", expected: `'\\\n\r\t'`},
+		{name: "byte escape", input: "\u0001", expected: `'\x01'`},
+		{name: "unicode escape", input: "\u200b", expected: `'\u200b'`},
+		{name: "long unicode escape", input: "\U0001d173", expected: `'\U0001d173'`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, quotePythonString(tt.input))
+		})
+	}
+}
+
+func TestNumberFormattingErrorsAndRepr(t *testing.T) {
+	t.Parallel()
+
+	_, err := formatInteger("not-an-integer")
+	require.ErrorContains(t, err, "invalid JSON integer")
+
+	integer, err := formatFloat("42")
+	require.NoError(t, err)
+	assert.Equal(t, "42", integer)
+
+	_, err = formatFloat("1.2.3")
+	require.ErrorContains(t, err, "invalid JSON number")
+
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{input: "1e309", expected: "inf"},
+		{input: "-1e309", expected: "-inf"},
+		{input: "1.5", expected: "1.5"},
+	}
+	for _, tt := range tests {
+		actual, err := formatPythonReprFloat(tt.input)
+		require.NoError(t, err)
+		assert.Equal(t, tt.expected, actual)
+	}
+
+	_, err = formatPythonReprFloat("1.2.3")
+	require.ErrorContains(t, err, "invalid JSON number")
+}
+
+func TestWrite_RejectsMalformedNodes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		node     *yaml.Node
+		contains string
+	}{
+		{name: "nil node", node: nil, contains: "cannot write a nil node"},
+		{name: "empty document", node: &yaml.Node{Kind: yaml.DocumentNode}, contains: "document must contain exactly one value"},
+		{name: "unsupported node", node: &yaml.Node{Kind: yaml.AliasNode}, contains: "unsupported YAML node kind"},
+		{name: "unmatched mapping key", node: &yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{stringNode("key")}}, contains: "mapping has an unmatched key"},
+		{name: "non-string mapping key", node: mappingNodeWithKey(intNode("1"), stringNode("value")), contains: "JSON object key must be a string"},
+		{name: "nil sequence child", node: sequenceNode(nil), contains: "cannot write a nil node"},
+		{name: "invalid integer", node: intNode("invalid"), contains: "invalid JSON integer"},
+		{name: "invalid float", node: floatNode("1.2.3"), contains: "invalid JSON number"},
+		{name: "unsupported scalar", node: &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!timestamp"}, contains: "unsupported scalar tag"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var output bytes.Buffer
+			require.ErrorContains(t, Write(tt.node, &output), tt.contains)
+		})
+	}
+}
+
+func TestPythonFloatAndExpansionAdditionalCases(t *testing.T) {
+	t.Parallel()
+
+	actual, err := pythonFloat(math.NaN())
+	require.NoError(t, err)
+	assert.Equal(t, "NaN", actual)
+
+	tests := []struct {
+		name     string
+		mantissa string
+		exponent int
+		expected string
+	}{
+		{name: "negative before digits", mantissa: "-1.2", exponent: -2, expected: "-0.012"},
+		{name: "negative after digits", mantissa: "-1.2", exponent: 3, expected: "-1200.0"},
+		{name: "negative within digits", mantissa: "-1.23", exponent: 1, expected: "-12.3"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, expandFloat(tt.mantissa, tt.exponent))
+		})
+	}
+}
+
+var errTestIO = errors.New("test I/O error")
+
+type failingReader struct{}
+
+func (failingReader) Read([]byte) (int, error) {
+	return 0, errTestIO
+}
+
+func stringNode(value string) *yaml.Node {
+	return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: value}
+}
+
+func boolNode(value string) *yaml.Node {
+	return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!bool", Value: value}
+}
+
+func intNode(value string) *yaml.Node {
+	return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!int", Value: value}
+}
+
+func floatNode(value string) *yaml.Node {
+	return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!float", Value: value}
+}
+
+func nullNode() *yaml.Node {
+	return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!null", Value: "null"}
+}
+
+func sequenceNode(values ...*yaml.Node) *yaml.Node {
+	return &yaml.Node{Kind: yaml.SequenceNode, Tag: "!!seq", Content: values}
+}
+
+func mappingNode(key string, value *yaml.Node) *yaml.Node {
+	return mappingNodeWithKey(stringNode(key), value)
+}
+
+func mappingNodeWithKey(key, value *yaml.Node) *yaml.Node {
+	return &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map", Content: []*yaml.Node{key, value}}
+}
+
+var _ io.Reader = failingReader{}

--- a/sortfmt/format.go
+++ b/sortfmt/format.go
@@ -309,13 +309,14 @@ func sortMapping(node *yaml.Node, parentKey string) error {
 		return left < right
 	})
 
-	node.Content = node.Content[:0]
+	sortedContent := make([]*yaml.Node, 0, len(pairs)*2)
 	for _, pair := range pairs {
 		if err := sortNode(pair.value, pair.key.Value); err != nil {
 			return err
 		}
-		node.Content = append(node.Content, pair.key, pair.value)
+		sortedContent = append(sortedContent, pair.key, pair.value)
 	}
+	node.Content = sortedContent
 
 	return nil
 }

--- a/sortfmt/format.go
+++ b/sortfmt/format.go
@@ -4,7 +4,10 @@
 // maps under paths, properties, and schemas, and sorts selected arrays by a
 // stable display key. It intentionally changes the order of parameters and
 // composition arrays, so callers should opt in only when sorted output is more
-// important than preserving authored array order.
+// important than preserving authored array order. Selected arrays whose sort
+// keys have different JSON types return an error, matching Python's ordering
+// behavior. Format also rejects lone UTF-16 surrogate escapes rather than
+// silently replacing them with a different character.
 package sortfmt
 
 import (
@@ -17,6 +20,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	"gopkg.in/yaml.v3"
 )
@@ -87,6 +91,10 @@ func Format(r io.Reader, w io.Writer) error {
 }
 
 func parseJSON(data []byte) (*yaml.Node, error) {
+	if !utf8.Valid(data) {
+		return nil, errors.New("parse JSON document: input is not valid UTF-8")
+	}
+
 	decoder := json.NewDecoder(bytes.NewReader(data))
 	decoder.UseNumber()
 
@@ -102,6 +110,10 @@ func parseJSON(data []byte) (*yaml.Node, error) {
 		return nil, fmt.Errorf("parse JSON document: %w", err)
 	}
 
+	if offset, ok := findLoneSurrogateEscape(data); ok {
+		return nil, fmt.Errorf("parse JSON document: lone surrogate escape at byte %d is not supported", offset)
+	}
+
 	content, err := jsonValueToNode(value)
 	if err != nil {
 		return nil, fmt.Errorf("parse JSON document: %w", err)
@@ -111,6 +123,68 @@ func parseJSON(data []byte) (*yaml.Node, error) {
 		Kind:    yaml.DocumentNode,
 		Content: []*yaml.Node{content},
 	}, nil
+}
+
+func findLoneSurrogateEscape(data []byte) (int, bool) {
+	inString := false
+	for i := 0; i < len(data); i++ {
+		switch data[i] {
+		case '"':
+			inString = !inString
+		case '\\':
+			if !inString || i+1 >= len(data) {
+				continue
+			}
+			if data[i+1] != 'u' {
+				i++
+				continue
+			}
+
+			codePoint, ok := parseHexCodeUnit(data, i+2)
+			if !ok {
+				continue
+			}
+			switch {
+			case codePoint >= 0xd800 && codePoint <= 0xdbff:
+				nextEscape := i + 6
+				if nextEscape+5 >= len(data) || data[nextEscape] != '\\' || data[nextEscape+1] != 'u' {
+					return i, true
+				}
+				lowSurrogate, validLow := parseHexCodeUnit(data, nextEscape+2)
+				if !validLow || lowSurrogate < 0xdc00 || lowSurrogate > 0xdfff {
+					return i, true
+				}
+				i = nextEscape + 5
+			case codePoint >= 0xdc00 && codePoint <= 0xdfff:
+				return i, true
+			default:
+				i += 5
+			}
+		}
+	}
+	return 0, false
+}
+
+func parseHexCodeUnit(data []byte, start int) (uint16, bool) {
+	if start+4 > len(data) {
+		return 0, false
+	}
+
+	var result uint16
+	for _, digit := range data[start : start+4] {
+		result <<= 4
+		switch {
+		case digit >= '0' && digit <= '9':
+			result |= uint16(digit - '0')
+		case digit >= 'a' && digit <= 'f':
+			result |= uint16(digit-'a') + 10
+		case digit >= 'A' && digit <= 'F':
+			result |= uint16(digit-'A') + 10
+		default:
+			return 0, false
+		}
+	}
+	return result, true
 }
 
 func jsonValueToNode(value any) (*yaml.Node, error) {
@@ -164,7 +238,7 @@ func Sort(node *yaml.Node) error {
 
 func sortNode(node *yaml.Node, parentKey string) error {
 	if node == nil {
-		return nil
+		return errors.New("cannot sort a nil node")
 	}
 
 	switch node.Kind {
@@ -197,10 +271,14 @@ func sortMapping(node *yaml.Node, parentKey string) error {
 	byKey := make(map[string]mappingPair, len(node.Content)/2)
 	for i := 0; i < len(node.Content); i += 2 {
 		keyNode := node.Content[i]
+		valueNode := node.Content[i+1]
+		if keyNode == nil || valueNode == nil {
+			return errors.New("mapping contains a nil key or value")
+		}
 		if keyNode.Kind != yaml.ScalarNode || keyNode.Tag != "!!str" {
 			return errors.New("JSON object key must be a string")
 		}
-		byKey[keyNode.Value] = mappingPair{key: keyNode, value: node.Content[i+1]}
+		byKey[keyNode.Value] = mappingPair{key: keyNode, value: valueNode}
 	}
 
 	pairs := make([]mappingPair, 0, len(byKey))
@@ -243,7 +321,10 @@ func sortMapping(node *yaml.Node, parentKey string) error {
 }
 
 func sortSequence(node *yaml.Node, parentKey string) error {
-	for _, child := range node.Content {
+	for i, child := range node.Content {
+		if child == nil {
+			return fmt.Errorf("%s item %d is nil", parentKey, i)
+		}
 		if err := sortNode(child, parentKey); err != nil {
 			return err
 		}
@@ -287,7 +368,7 @@ func sortSequence(node *yaml.Node, parentKey string) error {
 		return less
 	})
 	if comparisonErr != nil {
-		return comparisonErr
+		return fmt.Errorf("sort %s items: %w", parentKey, comparisonErr)
 	}
 	for i, item := range items {
 		node.Content[i] = item.node
@@ -402,7 +483,11 @@ func pythonRepr(node *yaml.Node) (string, error) {
 		case "!!str":
 			return quotePythonString(node.Value), nil
 		case "!!bool":
-			if node.Value == "true" {
+			value, err := boolValue(node.Value)
+			if err != nil {
+				return "", err
+			}
+			if value {
 				return "True", nil
 			}
 			return "False", nil
@@ -417,6 +502,17 @@ func pythonRepr(node *yaml.Node) (string, error) {
 		}
 	default:
 		return "", fmt.Errorf("unsupported YAML node kind %d", node.Kind)
+	}
+}
+
+func boolValue(value string) (bool, error) {
+	switch value {
+	case "true", "True", "TRUE":
+		return true, nil
+	case "false", "False", "FALSE":
+		return false, nil
+	default:
+		return false, fmt.Errorf("invalid boolean value %q", value)
 	}
 }
 

--- a/sortfmt/format.go
+++ b/sortfmt/format.go
@@ -1,0 +1,501 @@
+// Package sortfmt provides deterministic JSON formatting for OpenAPI documents.
+//
+// The formatter orders mapping keys using a fixed priority list, alphabetizes
+// maps under paths, properties, and schemas, and sorts selected arrays by a
+// stable display key. It intentionally changes the order of parameters and
+// composition arrays, so callers should opt in only when sorted output is more
+// important than preserving authored array order.
+package sortfmt
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"sort"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+var alphabetizedMapKeys = map[string]struct{}{
+	"paths":      {},
+	"properties": {},
+	"schemas":    {},
+}
+
+var sortedListKeys = map[string]struct{}{
+	"required":   {},
+	"parameters": {},
+	"oneOf":      {},
+	"anyOf":      {},
+	"allOf":      {},
+}
+
+var keyPriority = func() map[string]int {
+	keys := []string{
+		"openapi",
+		"info",
+		"servers",
+		"paths",
+		"components",
+		"title",
+		"url",
+		"name",
+		"in",
+		"operationId",
+		"description",
+		"parameters",
+		"type",
+		"properties",
+		"required",
+		"examples",
+	}
+
+	result := make(map[string]int, len(keys))
+	for i, key := range keys {
+		result[key] = i
+	}
+	return result
+}()
+
+// Format reads a JSON document, applies the sorted formatting style, and
+// writes two-space-indented JSON with a trailing newline.
+func Format(r io.Reader, w io.Writer) error {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return fmt.Errorf("read document: %w", err)
+	}
+
+	document, err := parseJSON(data)
+	if err != nil {
+		return err
+	}
+
+	if err := Sort(document); err != nil {
+		return fmt.Errorf("sort document: %w", err)
+	}
+
+	if err := Write(document, w); err != nil {
+		return fmt.Errorf("write document: %w", err)
+	}
+
+	return nil
+}
+
+func parseJSON(data []byte) (*yaml.Node, error) {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return nil, fmt.Errorf("parse JSON document: %w", err)
+	}
+
+	if err := decoder.Decode(&value); err != io.EOF {
+		if err == nil {
+			return nil, errors.New("parse JSON document: multiple JSON values")
+		}
+		return nil, fmt.Errorf("parse JSON document: %w", err)
+	}
+
+	content, err := jsonValueToNode(value)
+	if err != nil {
+		return nil, fmt.Errorf("parse JSON document: %w", err)
+	}
+
+	return &yaml.Node{
+		Kind:    yaml.DocumentNode,
+		Content: []*yaml.Node{content},
+	}, nil
+}
+
+func jsonValueToNode(value any) (*yaml.Node, error) {
+	switch typedValue := value.(type) {
+	case map[string]any:
+		node := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+		for key, childValue := range typedValue {
+			child, err := jsonValueToNode(childValue)
+			if err != nil {
+				return nil, err
+			}
+			node.Content = append(node.Content,
+				&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key},
+				child,
+			)
+		}
+		return node, nil
+	case []any:
+		node := &yaml.Node{Kind: yaml.SequenceNode, Tag: "!!seq"}
+		for _, childValue := range typedValue {
+			child, err := jsonValueToNode(childValue)
+			if err != nil {
+				return nil, err
+			}
+			node.Content = append(node.Content, child)
+		}
+		return node, nil
+	case string:
+		return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: typedValue}, nil
+	case json.Number:
+		tag := "!!int"
+		if strings.ContainsAny(string(typedValue), ".eE") {
+			tag = "!!float"
+		}
+		return &yaml.Node{Kind: yaml.ScalarNode, Tag: tag, Value: string(typedValue)}, nil
+	case bool:
+		return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!bool", Value: strconv.FormatBool(typedValue)}, nil
+	case nil:
+		return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!null", Value: "null"}, nil
+	default:
+		return nil, fmt.Errorf("unsupported JSON value type %T", value)
+	}
+}
+
+// Sort applies the sorted formatting order to a YAML node in place. The node
+// must represent data parsed from JSON. Duplicate object keys retain their last
+// value, matching encoding/json and Python's json module.
+func Sort(node *yaml.Node) error {
+	return sortNode(node, "")
+}
+
+func sortNode(node *yaml.Node, parentKey string) error {
+	if node == nil {
+		return nil
+	}
+
+	switch node.Kind {
+	case yaml.DocumentNode:
+		if len(node.Content) != 1 {
+			return errors.New("document must contain exactly one value")
+		}
+		return sortNode(node.Content[0], parentKey)
+	case yaml.MappingNode:
+		return sortMapping(node, parentKey)
+	case yaml.SequenceNode:
+		return sortSequence(node, parentKey)
+	case yaml.ScalarNode:
+		return nil
+	default:
+		return fmt.Errorf("unsupported YAML node kind %d", node.Kind)
+	}
+}
+
+type mappingPair struct {
+	key   *yaml.Node
+	value *yaml.Node
+}
+
+func sortMapping(node *yaml.Node, parentKey string) error {
+	if len(node.Content)%2 != 0 {
+		return errors.New("mapping has an unmatched key")
+	}
+
+	byKey := make(map[string]mappingPair, len(node.Content)/2)
+	for i := 0; i < len(node.Content); i += 2 {
+		keyNode := node.Content[i]
+		if keyNode.Kind != yaml.ScalarNode || keyNode.Tag != "!!str" {
+			return errors.New("JSON object key must be a string")
+		}
+		byKey[keyNode.Value] = mappingPair{key: keyNode, value: node.Content[i+1]}
+	}
+
+	pairs := make([]mappingPair, 0, len(byKey))
+	for _, pair := range byKey {
+		pairs = append(pairs, pair)
+	}
+
+	_, alphabetize := alphabetizedMapKeys[parentKey]
+	sort.Slice(pairs, func(i, j int) bool {
+		left := pairs[i].key.Value
+		right := pairs[j].key.Value
+		if alphabetize {
+			return left < right
+		}
+
+		leftPriority, leftPrioritized := keyPriority[left]
+		if !leftPrioritized {
+			leftPriority = len(keyPriority)
+		}
+		rightPriority, rightPrioritized := keyPriority[right]
+		if !rightPrioritized {
+			rightPriority = len(keyPriority)
+		}
+
+		if leftPriority != rightPriority {
+			return leftPriority < rightPriority
+		}
+		return left < right
+	})
+
+	node.Content = node.Content[:0]
+	for _, pair := range pairs {
+		if err := sortNode(pair.value, pair.key.Value); err != nil {
+			return err
+		}
+		node.Content = append(node.Content, pair.key, pair.value)
+	}
+
+	return nil
+}
+
+func sortSequence(node *yaml.Node, parentKey string) error {
+	for _, child := range node.Content {
+		if err := sortNode(child, parentKey); err != nil {
+			return err
+		}
+	}
+
+	if _, ok := sortedListKeys[parentKey]; !ok {
+		return nil
+	}
+	if len(node.Content) < 2 {
+		return nil
+	}
+
+	keys := make([]pythonSortKey, len(node.Content))
+	for i, child := range node.Content {
+		key, err := listSortKey(child)
+		if err != nil {
+			return fmt.Errorf("create sort key for %s item %d: %w", parentKey, i, err)
+		}
+		keys[i] = key
+	}
+
+	type sequenceItem struct {
+		node *yaml.Node
+		key  pythonSortKey
+	}
+	items := make([]sequenceItem, len(node.Content))
+	for i, child := range node.Content {
+		items[i] = sequenceItem{node: child, key: keys[i]}
+	}
+
+	var comparisonErr error
+	sort.SliceStable(items, func(i, j int) bool {
+		if comparisonErr != nil {
+			return false
+		}
+		less, err := items[i].key.less(items[j].key)
+		if err != nil {
+			comparisonErr = err
+			return false
+		}
+		return less
+	})
+	if comparisonErr != nil {
+		return comparisonErr
+	}
+	for i, item := range items {
+		node.Content[i] = item.node
+	}
+
+	return nil
+}
+
+type pythonSortKeyKind int
+
+const (
+	pythonSortKeyString pythonSortKeyKind = iota
+	pythonSortKeyStringList
+)
+
+type pythonSortKey struct {
+	kind        pythonSortKeyKind
+	stringValue string
+	stringList  []string
+}
+
+func newPythonStringSortKey(value string) pythonSortKey {
+	return pythonSortKey{kind: pythonSortKeyString, stringValue: value}
+}
+
+func (k pythonSortKey) less(other pythonSortKey) (bool, error) {
+	if k.kind != other.kind {
+		return false, errors.New("cannot compare selected-list sort keys of different JSON types")
+	}
+
+	switch k.kind {
+	case pythonSortKeyString:
+		return k.stringValue < other.stringValue, nil
+	case pythonSortKeyStringList:
+		for i := 0; i < min(len(k.stringList), len(other.stringList)); i++ {
+			if k.stringList[i] != other.stringList[i] {
+				return k.stringList[i] < other.stringList[i], nil
+			}
+		}
+		return len(k.stringList) < len(other.stringList), nil
+	default:
+		return false, fmt.Errorf("unsupported selected-list sort key kind %d", k.kind)
+	}
+}
+
+func listSortKey(node *yaml.Node) (pythonSortKey, error) {
+	if node.Kind == yaml.MappingNode {
+		for _, key := range []string{"name", "$ref", "type"} {
+			if value, ok := mappingValue(node, key); ok {
+				switch {
+				case value.Kind == yaml.ScalarNode && value.Tag == "!!str":
+					return newPythonStringSortKey(value.Value), nil
+				case value.Kind == yaml.SequenceNode:
+					items := make([]string, len(value.Content))
+					for i, item := range value.Content {
+						if item.Kind != yaml.ScalarNode || item.Tag != "!!str" {
+							return pythonSortKey{}, fmt.Errorf("%s array sort key item %d must be a string", key, i)
+						}
+						items[i] = item.Value
+					}
+					return pythonSortKey{kind: pythonSortKeyStringList, stringList: items}, nil
+				default:
+					return pythonSortKey{}, fmt.Errorf("%s sort key must be a string or string array", key)
+				}
+			}
+		}
+		value, err := pythonRepr(node)
+		return newPythonStringSortKey(value), err
+	}
+
+	if node.Kind == yaml.ScalarNode && node.Tag == "!!str" {
+		return newPythonStringSortKey(node.Value), nil
+	}
+
+	value, err := pythonRepr(node)
+	return newPythonStringSortKey(value), err
+}
+
+func mappingValue(node *yaml.Node, key string) (*yaml.Node, bool) {
+	for i := 0; i < len(node.Content); i += 2 {
+		if node.Content[i].Value == key {
+			return node.Content[i+1], true
+		}
+	}
+	return nil, false
+}
+
+func pythonRepr(node *yaml.Node) (string, error) {
+	switch node.Kind {
+	case yaml.MappingNode:
+		parts := make([]string, 0, len(node.Content)/2)
+		for i := 0; i < len(node.Content); i += 2 {
+			value, err := pythonRepr(node.Content[i+1])
+			if err != nil {
+				return "", err
+			}
+			parts = append(parts, quotePythonString(node.Content[i].Value)+": "+value)
+		}
+		return "{" + strings.Join(parts, ", ") + "}", nil
+	case yaml.SequenceNode:
+		parts := make([]string, len(node.Content))
+		for i, child := range node.Content {
+			value, err := pythonRepr(child)
+			if err != nil {
+				return "", err
+			}
+			parts[i] = value
+		}
+		return "[" + strings.Join(parts, ", ") + "]", nil
+	case yaml.ScalarNode:
+		switch node.Tag {
+		case "!!str":
+			return quotePythonString(node.Value), nil
+		case "!!bool":
+			if node.Value == "true" {
+				return "True", nil
+			}
+			return "False", nil
+		case "!!null":
+			return "None", nil
+		case "!!int":
+			return formatInteger(node.Value)
+		case "!!float":
+			return formatPythonReprFloat(node.Value)
+		default:
+			return "", fmt.Errorf("unsupported scalar tag %s", node.Tag)
+		}
+	default:
+		return "", fmt.Errorf("unsupported YAML node kind %d", node.Kind)
+	}
+}
+
+func quotePythonString(value string) string {
+	quote := byte('\'')
+	if strings.ContainsRune(value, '\'') && !strings.ContainsRune(value, '"') {
+		quote = '"'
+	}
+
+	var result strings.Builder
+	result.WriteByte(quote)
+	for _, r := range value {
+		switch r {
+		case '\\':
+			result.WriteString(`\\`)
+		case '\n':
+			result.WriteString(`\n`)
+		case '\r':
+			result.WriteString(`\r`)
+		case '\t':
+			result.WriteString(`\t`)
+		default:
+			switch {
+			case r == rune(quote):
+				result.WriteByte('\\')
+				result.WriteRune(r)
+			case strconv.IsPrint(r):
+				result.WriteRune(r)
+			default:
+				switch {
+				case r <= 0xff:
+					fmt.Fprintf(&result, `\x%02x`, r)
+				case r <= 0xffff:
+					fmt.Fprintf(&result, `\u%04x`, r)
+				default:
+					fmt.Fprintf(&result, `\U%08x`, r)
+				}
+			}
+		}
+	}
+	result.WriteByte(quote)
+	return result.String()
+}
+
+func formatInteger(value string) (string, error) {
+	var integer big.Int
+	if _, ok := integer.SetString(value, 10); !ok {
+		return "", fmt.Errorf("invalid JSON integer %q", value)
+	}
+	return integer.String(), nil
+}
+
+func formatFloat(value string) (string, error) {
+	// Preserve integer-shaped numeric tokens when Sort is called on a YAML node.
+	if !strings.ContainsAny(value, ".eE") {
+		return formatInteger(value)
+	}
+
+	number, err := strconv.ParseFloat(value, 64)
+	if err != nil && !errors.Is(err, strconv.ErrRange) {
+		return "", fmt.Errorf("invalid JSON number %q: %w", value, err)
+	}
+	return pythonFloat(number)
+}
+
+func formatPythonReprFloat(value string) (string, error) {
+	formatted, err := formatFloat(value)
+	if err != nil {
+		return "", err
+	}
+
+	switch formatted {
+	case "Infinity":
+		return "inf", nil
+	case "-Infinity":
+		return "-inf", nil
+	case "NaN":
+		return "nan", nil
+	default:
+		return formatted, nil
+	}
+}

--- a/sortfmt/format_test.go
+++ b/sortfmt/format_test.go
@@ -259,6 +259,11 @@ func TestFormat_EdgeCaseGolden(t *testing.T) {
 	err = Format(input, &actual)
 	require.NoError(t, err, "edge-case formatting should succeed")
 	assert.Equal(t, expected, actual.Bytes(), "edge-case output should match the reference golden")
+
+	var idempotent bytes.Buffer
+	err = Format(bytes.NewReader(expected), &idempotent)
+	require.NoError(t, err, "reference-formatted output should be accepted")
+	assert.Equal(t, expected, idempotent.Bytes(), "reference-formatted output should be idempotent")
 }
 
 func TestFormat_ReferenceParity(t *testing.T) {

--- a/sortfmt/format_test.go
+++ b/sortfmt/format_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func TestFormat_MatchesSortedJSONStyle(t *testing.T) {
@@ -163,6 +164,65 @@ func TestFormat_SortsArrayValuedTypeKeys(t *testing.T) {
 	assert.Equal(t, expected, output.String(), "array-valued types should use Python list ordering")
 }
 
+func TestFormat_MixedSortKeyKindsMatchReferenceError(t *testing.T) {
+	t.Parallel()
+
+	var output bytes.Buffer
+	err := Format(
+		strings.NewReader(`{"oneOf":[{"type":"string"},{"type":["string","null"]}]}`),
+		&output,
+	)
+	require.ErrorContains(t, err, "sort oneOf items", "mixed Python sort-key types should fail")
+	assert.Empty(t, output.String(), "sorting errors should not produce partial output")
+}
+
+func TestFormat_RejectsLoneSurrogateEscapes(t *testing.T) {
+	t.Parallel()
+
+	inputs := []string{
+		`{"a":"\ud83d"}`,
+		`{"a":"\ude00"}`,
+		`{"a":"\ude00\ud83d"}`,
+		`{"\ud83d":1}`,
+	}
+	for _, input := range inputs {
+		t.Run(input, func(t *testing.T) {
+			t.Parallel()
+
+			var output bytes.Buffer
+			err := Format(strings.NewReader(input), &output)
+			require.ErrorContains(t, err, "lone surrogate escape")
+			assert.Empty(t, output.String(), "parse errors should not produce output")
+		})
+	}
+}
+
+func TestFormat_AcceptsPairedAndEscapedSurrogates(t *testing.T) {
+	t.Parallel()
+
+	inputs := []string{
+		`{"a":"\ud83d\ude00"}`,
+		`{"a":"\uD83D\uDE00"}`,
+		`{"a":"C:\\ud83d"}`,
+	}
+	for _, input := range inputs {
+		t.Run(input, func(t *testing.T) {
+			t.Parallel()
+
+			var output bytes.Buffer
+			require.NoError(t, Format(strings.NewReader(input), &output))
+		})
+	}
+}
+
+func TestFormat_RejectsInvalidUTF8(t *testing.T) {
+	t.Parallel()
+
+	var output bytes.Buffer
+	err := Format(bytes.NewReader([]byte{'{', '"', 'a', '"', ':', '"', 0xff, '"', '}'}), &output)
+	require.ErrorContains(t, err, "input is not valid UTF-8")
+}
+
 func TestFormat_MatchesPythonFallbackSortKeys(t *testing.T) {
 	t.Parallel()
 
@@ -250,6 +310,97 @@ func TestPythonFloat_Success(t *testing.T) {
 			actual, err := pythonFloat(tt.value)
 			require.NoError(t, err, "float formatting should succeed")
 			assert.Equal(t, tt.expected, actual, "float should use Python repr formatting")
+		})
+	}
+}
+
+func TestWrite_BooleanSpellings(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		value    string
+		expected string
+	}{
+		{value: "true", expected: "true\n"},
+		{value: "True", expected: "true\n"},
+		{value: "TRUE", expected: "true\n"},
+		{value: "false", expected: "false\n"},
+		{value: "False", expected: "false\n"},
+		{value: "FALSE", expected: "false\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			t.Parallel()
+
+			var output bytes.Buffer
+			err := Write(&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!bool", Value: tt.value}, &output)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, output.String())
+		})
+	}
+}
+
+func TestWrite_InvalidBooleanReturnsError(t *testing.T) {
+	t.Parallel()
+
+	var output bytes.Buffer
+	err := Write(&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!bool", Value: "yes"}, &output)
+	require.ErrorContains(t, err, "invalid boolean value")
+}
+
+func TestPythonRepr_BooleanSpellings(t *testing.T) {
+	t.Parallel()
+
+	trueValue, err := pythonRepr(&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!bool", Value: "TRUE"})
+	require.NoError(t, err)
+	assert.Equal(t, "True", trueValue)
+
+	falseValue, err := pythonRepr(&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!bool", Value: "False"})
+	require.NoError(t, err)
+	assert.Equal(t, "False", falseValue)
+}
+
+func TestSort_NilNodesReturnErrors(t *testing.T) {
+	t.Parallel()
+
+	stringNode := func(value string) *yaml.Node {
+		return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: value}
+	}
+	tests := map[string]*yaml.Node{
+		"root":           nil,
+		"mapping key":    {Kind: yaml.MappingNode, Tag: "!!map", Content: []*yaml.Node{nil, stringNode("value")}},
+		"mapping value":  {Kind: yaml.MappingNode, Tag: "!!map", Content: []*yaml.Node{stringNode("key"), nil}},
+		"sequence child": {Kind: yaml.SequenceNode, Tag: "!!seq", Content: []*yaml.Node{nil}},
+	}
+	for name, node := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.NotPanics(t, func() {
+				require.Error(t, Sort(node))
+			})
+		})
+	}
+}
+
+func TestWrite_NilMappingEntriesReturnErrors(t *testing.T) {
+	t.Parallel()
+
+	stringNode := func(value string) *yaml.Node {
+		return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: value}
+	}
+	tests := map[string]*yaml.Node{
+		"key":   {Kind: yaml.MappingNode, Tag: "!!map", Content: []*yaml.Node{nil, stringNode("value")}},
+		"value": {Kind: yaml.MappingNode, Tag: "!!map", Content: []*yaml.Node{stringNode("key"), nil}},
+	}
+	for name, node := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.NotPanics(t, func() {
+				var output bytes.Buffer
+				require.Error(t, Write(node, &output))
+			})
 		})
 	}
 }

--- a/sortfmt/format_test.go
+++ b/sortfmt/format_test.go
@@ -1,0 +1,273 @@
+package sortfmt
+
+import (
+	"bytes"
+	"io"
+	"math"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormat_MatchesSortedJSONStyle(t *testing.T) {
+	t.Parallel()
+
+	input := `{"z":"café \ud83d\ude00 <>&","components":{"schemas":{"Z":{"required":["z","a"],"oneOf":[{"type":"string"},{"$ref":"#/A"}],"properties":{"b":{"description":"b","type":"string"},"a":{"type":"number","default":1e7}}},"A":{}}},"openapi":"3.0.0","servers":[],"tags":["z","a"],"parameters":[{"name":"z"},{"$ref":"#/p"},{"name":"a"}],"duplicate":"first","duplicate":"last","negativeZero":-0.0,"small":1e-5}`
+	expected := `{
+  "openapi": "3.0.0",
+  "servers": [],
+  "components": {
+    "schemas": {
+      "A": {},
+      "Z": {
+        "properties": {
+          "a": {
+            "type": "number",
+            "default": 10000000.0
+          },
+          "b": {
+            "description": "b",
+            "type": "string"
+          }
+        },
+        "required": [
+          "a",
+          "z"
+        ],
+        "oneOf": [
+          {
+            "$ref": "#/A"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      }
+    }
+  },
+  "parameters": [
+    {
+      "$ref": "#/p"
+    },
+    {
+      "name": "a"
+    },
+    {
+      "name": "z"
+    }
+  ],
+  "duplicate": "last",
+  "negativeZero": -0.0,
+  "small": 1e-05,
+  "tags": [
+    "z",
+    "a"
+  ],
+  "z": "caf\u00e9 \ud83d\ude00 <>&"
+}
+`
+
+	var output bytes.Buffer
+	err := Format(strings.NewReader(input), &output)
+	require.NoError(t, err, "format should succeed")
+	assert.Equal(t, expected, output.String(), "output should match the sorted JSON style")
+}
+
+func TestFormat_IsIdempotentAndPermutationInvariant(t *testing.T) {
+	t.Parallel()
+
+	first := `{"openapi":"3.0.0","paths":{"/z":{},"/a":{}},"components":{"schemas":{"Z":{"required":["z","a"]},"A":{}}},"parameters":[{"name":"z"},{"name":"a"}],"tags":["z","a"]}`
+	second := `{"tags":["z","a"],"parameters":[{"name":"a"},{"name":"z"}],"components":{"schemas":{"A":{},"Z":{"required":["a","z"]}}},"paths":{"/a":{},"/z":{}},"openapi":"3.0.0"}`
+
+	firstOutput := formatForTest(t, first)
+	secondOutput := formatForTest(t, second)
+	assert.Equal(t, firstOutput, secondOutput, "key and selected-array permutations should converge")
+
+	idempotentOutput := formatForTest(t, firstOutput)
+	assert.Equal(t, firstOutput, idempotentOutput, "formatting an output twice should not change it")
+
+	differentTags := strings.Replace(first, `"tags":["z","a"]`, `"tags":["a","z"]`, 1)
+	differentTagsOutput := formatForTest(t, differentTags)
+	assert.NotEqual(t, firstOutput, differentTagsOutput, "non-selected array order should be preserved")
+}
+
+func TestFormat_InvalidJSONReturnsError(t *testing.T) {
+	t.Parallel()
+
+	var output bytes.Buffer
+	err := Format(strings.NewReader(`{"openapi":}`), &output)
+	require.Error(t, err, "invalid JSON should fail")
+}
+
+func TestFormat_ShortWriteReturnsError(t *testing.T) {
+	t.Parallel()
+
+	err := Format(strings.NewReader(`{"openapi":"3.0.0"}`), shortWriter{})
+	require.ErrorIs(t, err, io.ErrShortWrite, "short writes should be reported")
+}
+
+func TestFormat_MatchesPythonNumberRangeSemantics(t *testing.T) {
+	t.Parallel()
+
+	input := `{"positiveOverflow":1e309,"negativeOverflow":-1e309,"underflow":1e-400}`
+	expected := `{
+  "negativeOverflow": -Infinity,
+  "positiveOverflow": Infinity,
+  "underflow": 0.0
+}
+`
+
+	var output bytes.Buffer
+	err := Format(strings.NewReader(input), &output)
+	require.NoError(t, err, "range-limited floats should use Python JSON semantics")
+	assert.Equal(t, expected, output.String(), "range-limited floats should match Python output")
+}
+
+func TestFormat_SortsArrayValuedTypeKeys(t *testing.T) {
+	t.Parallel()
+
+	input := `{"oneOf":[{"type":["string","null"]},{"type":["integer","null"]}],"anyOf":[{"type":["string","null"]}]}`
+	expected := `{
+  "anyOf": [
+    {
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  ],
+  "oneOf": [
+    {
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    {
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  ]
+}
+`
+
+	var output bytes.Buffer
+	err := Format(strings.NewReader(input), &output)
+	require.NoError(t, err, "OpenAPI 3.1 array-valued types should sort")
+	assert.Equal(t, expected, output.String(), "array-valued types should use Python list ordering")
+}
+
+func TestFormat_MatchesPythonFallbackSortKeys(t *testing.T) {
+	t.Parallel()
+
+	input := `{"oneOf":[{"maximum":1e309},{"maximum":true}]}`
+	expected := `{
+  "oneOf": [
+    {
+      "maximum": true
+    },
+    {
+      "maximum": Infinity
+    }
+  ]
+}
+`
+
+	var output bytes.Buffer
+	err := Format(strings.NewReader(input), &output)
+	require.NoError(t, err, "fallback keys should use Python representations")
+	assert.Equal(t, expected, output.String(), "non-finite fallback keys should use lowercase Python repr ordering")
+}
+
+func TestFormat_EdgeCaseGolden(t *testing.T) {
+	t.Parallel()
+
+	input, err := os.Open("testdata/edge_cases.json")
+	require.NoError(t, err, "edge-case input should be readable")
+	defer input.Close()
+
+	expected, err := os.ReadFile("testdata/edge_cases.expected.json")
+	require.NoError(t, err, "edge-case golden should be readable")
+
+	var actual bytes.Buffer
+	err = Format(input, &actual)
+	require.NoError(t, err, "edge-case formatting should succeed")
+	assert.Equal(t, expected, actual.Bytes(), "edge-case output should match the reference golden")
+}
+
+func TestFormat_ReferenceParity(t *testing.T) {
+	t.Parallel()
+
+	referenceScript := os.Getenv("SORTFMT_REFERENCE_SCRIPT")
+	referenceInput := os.Getenv("SORTFMT_REFERENCE_INPUT")
+	if referenceScript == "" || referenceInput == "" {
+		t.Skip("set SORTFMT_REFERENCE_SCRIPT and SORTFMT_REFERENCE_INPUT to run the differential test")
+	}
+
+	input, err := os.ReadFile(referenceInput)
+	require.NoError(t, err, "reference input should be readable")
+
+	command := exec.CommandContext(t.Context(), "python3", referenceScript)
+	command.Stdin = bytes.NewReader(input)
+	expected, err := command.Output()
+	require.NoError(t, err, "reference formatter should succeed")
+
+	var actual bytes.Buffer
+	err = Format(bytes.NewReader(input), &actual)
+	require.NoError(t, err, "Go formatter should succeed")
+	assert.Equal(t, expected, actual.Bytes(), "Go output should match the reference formatter byte-for-byte")
+}
+
+func TestPythonFloat_Success(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		value    float64
+		expected string
+	}{
+		{name: "positive zero", value: 0, expected: "0.0"},
+		{name: "fixed upper threshold", value: 1e15, expected: "1000000000000000.0"},
+		{name: "scientific upper threshold", value: 1e16, expected: "1e+16"},
+		{name: "fixed lower threshold", value: 1e-4, expected: "0.0001"},
+		{name: "scientific lower threshold", value: 1e-5, expected: "1e-05"},
+		{name: "expanded integer", value: 1e7, expected: "10000000.0"},
+		{name: "fraction", value: 1.25, expected: "1.25"},
+		{name: "positive infinity", value: math.Inf(1), expected: "Infinity"},
+		{name: "negative infinity", value: math.Inf(-1), expected: "-Infinity"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual, err := pythonFloat(tt.value)
+			require.NoError(t, err, "float formatting should succeed")
+			assert.Equal(t, tt.expected, actual, "float should use Python repr formatting")
+		})
+	}
+}
+
+func formatForTest(t *testing.T, input string) string {
+	t.Helper()
+
+	var output bytes.Buffer
+	err := Format(strings.NewReader(input), &output)
+	require.NoError(t, err, "format should succeed")
+	return output.String()
+}
+
+type shortWriter struct{}
+
+func (shortWriter) Write(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	return len(p) - 1, nil
+}

--- a/sortfmt/testdata/edge_cases.expected.json
+++ b/sortfmt/testdata/edge_cases.expected.json
@@ -1,0 +1,79 @@
+{
+  "openapi": "3.0.0",
+  "paths": {
+    "/A": {},
+    "/a": {},
+    "/z": {}
+  },
+  "parameters": [
+    {
+      "$ref": "#/parameters/shared"
+    },
+    {
+      "name": "a"
+    },
+    {
+      "type": "array"
+    },
+    {
+      "name": "z"
+    }
+  ],
+  "properties": {
+    "A": {
+      "type": "string"
+    },
+    "a": {
+      "type": "string"
+    },
+    "z": {
+      "type": "string"
+    }
+  },
+  "required": [
+    10,
+    10000000.0,
+    2,
+    false,
+    null,
+    true,
+    "a",
+    "z"
+  ],
+  "duplicate": "last",
+  "numbers": {
+    "fixedLower": 0.0001,
+    "fixedUpper": 1000000000000000.0,
+    "largeInteger": 123456789012345678901234567890,
+    "negativeZeroFloat": -0.0,
+    "negativeZeroInteger": 0,
+    "precise": 1.2345678901234567,
+    "scientificLower": 1e-05,
+    "scientificUpper": 1e+16,
+    "trimmed": 1.5
+  },
+  "oneOf": [
+    10,
+    2,
+    false,
+    null,
+    true,
+    {
+      "description": "\u2028",
+      "default": "a'b"
+    },
+    {
+      "description": "\u0080",
+      "default": "a\"b"
+    },
+    {
+      "description": "a",
+      "default": null
+    },
+    {
+      "description": "z",
+      "default": true
+    }
+  ],
+  "z": "\u007f caf\u00e9 \ud83d\ude00 <>& /\b\t\n\f\r"
+}

--- a/sortfmt/testdata/edge_cases.json
+++ b/sortfmt/testdata/edge_cases.json
@@ -1,0 +1,45 @@
+{
+  "z": "\u007f café 😀 <>& /\b\t\n\f\r",
+  "openapi": "3.0.0",
+  "paths": {
+    "/z": {},
+    "/A": {},
+    "/a": {}
+  },
+  "properties": {
+    "z": {"type": "string"},
+    "A": {"type": "string"},
+    "a": {"type": "string"}
+  },
+  "required": [true, false, null, 10, 2, 1e7, "z", "a"],
+  "parameters": [
+    {"name": "z"},
+    {"$ref": "#/parameters/shared"},
+    {"type": "array"},
+    {"name": "a"}
+  ],
+  "oneOf": [
+    {"description": "z", "default": true},
+    {"description": "a", "default": null},
+    {"description": "\u2028", "default": "a'b"},
+    {"description": "\u0080", "default": "a\"b"},
+    false,
+    true,
+    2,
+    10,
+    null
+  ],
+  "numbers": {
+    "negativeZeroInteger": -0,
+    "negativeZeroFloat": -0.0,
+    "largeInteger": 123456789012345678901234567890,
+    "fixedUpper": 1e15,
+    "scientificUpper": 1e16,
+    "fixedLower": 1e-4,
+    "scientificLower": 1e-5,
+    "trimmed": 1.5000,
+    "precise": 1.2345678901234567
+  },
+  "duplicate": "first",
+  "duplicate": "last"
+}

--- a/sortfmt/writer.go
+++ b/sortfmt/writer.go
@@ -1,0 +1,248 @@
+package sortfmt
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"strconv"
+	"strings"
+	"unicode/utf16"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Write serializes a sorted YAML node using the JSON representation produced
+// by Python's json.dump with indent=2, followed by one trailing newline.
+func Write(node *yaml.Node, w io.Writer) error {
+	writer := &jsonWriter{w: w}
+	if err := writer.writeNode(node, 0); err != nil {
+		return err
+	}
+	writer.writeString("\n")
+	return writer.err
+}
+
+type jsonWriter struct {
+	w   io.Writer
+	err error
+}
+
+func (w *jsonWriter) writeString(value string) {
+	if w.err != nil {
+		return
+	}
+	written, err := io.WriteString(w.w, value)
+	if err == nil && written != len(value) {
+		err = io.ErrShortWrite
+	}
+	w.err = err
+}
+
+func (w *jsonWriter) writeIndent(depth int) {
+	w.writeString(strings.Repeat("  ", depth))
+}
+
+func (w *jsonWriter) writeNode(node *yaml.Node, depth int) error {
+	if node == nil {
+		return errors.New("cannot write a nil node")
+	}
+
+	switch node.Kind {
+	case yaml.DocumentNode:
+		if len(node.Content) != 1 {
+			return errors.New("document must contain exactly one value")
+		}
+		return w.writeNode(node.Content[0], depth)
+	case yaml.MappingNode:
+		return w.writeMapping(node, depth)
+	case yaml.SequenceNode:
+		return w.writeSequence(node, depth)
+	case yaml.ScalarNode:
+		return w.writeScalar(node)
+	default:
+		return fmt.Errorf("unsupported YAML node kind %d", node.Kind)
+	}
+}
+
+func (w *jsonWriter) writeMapping(node *yaml.Node, depth int) error {
+	if len(node.Content)%2 != 0 {
+		return errors.New("mapping has an unmatched key")
+	}
+	if len(node.Content) == 0 {
+		w.writeString("{}")
+		return w.err
+	}
+
+	w.writeString("{\n")
+	for i := 0; i < len(node.Content); i += 2 {
+		keyNode := node.Content[i]
+		if keyNode.Kind != yaml.ScalarNode || keyNode.Tag != "!!str" {
+			return errors.New("JSON object key must be a string")
+		}
+
+		w.writeIndent(depth + 1)
+		w.writeString(quoteJSONString(keyNode.Value))
+		w.writeString(": ")
+		if err := w.writeNode(node.Content[i+1], depth+1); err != nil {
+			return err
+		}
+		if i+2 < len(node.Content) {
+			w.writeString(",")
+		}
+		w.writeString("\n")
+	}
+	w.writeIndent(depth)
+	w.writeString("}")
+	return w.err
+}
+
+func (w *jsonWriter) writeSequence(node *yaml.Node, depth int) error {
+	if len(node.Content) == 0 {
+		w.writeString("[]")
+		return w.err
+	}
+
+	w.writeString("[\n")
+	for i, child := range node.Content {
+		w.writeIndent(depth + 1)
+		if err := w.writeNode(child, depth+1); err != nil {
+			return err
+		}
+		if i+1 < len(node.Content) {
+			w.writeString(",")
+		}
+		w.writeString("\n")
+	}
+	w.writeIndent(depth)
+	w.writeString("]")
+	return w.err
+}
+
+func (w *jsonWriter) writeScalar(node *yaml.Node) error {
+	switch node.Tag {
+	case "!!str":
+		w.writeString(quoteJSONString(node.Value))
+	case "!!bool":
+		if node.Value == "true" {
+			w.writeString("true")
+		} else {
+			w.writeString("false")
+		}
+	case "!!null":
+		w.writeString("null")
+	case "!!int":
+		value, err := formatInteger(node.Value)
+		if err != nil {
+			return err
+		}
+		w.writeString(value)
+	case "!!float":
+		value, err := formatFloat(node.Value)
+		if err != nil {
+			return err
+		}
+		w.writeString(value)
+	default:
+		return fmt.Errorf("unsupported scalar tag %s", node.Tag)
+	}
+	return w.err
+}
+
+func quoteJSONString(value string) string {
+	var result strings.Builder
+	result.WriteByte('"')
+	for _, r := range value {
+		switch r {
+		case '"':
+			result.WriteString(`\"`)
+		case '\\':
+			result.WriteString(`\\`)
+		case '\b':
+			result.WriteString(`\b`)
+		case '\t':
+			result.WriteString(`\t`)
+		case '\n':
+			result.WriteString(`\n`)
+		case '\f':
+			result.WriteString(`\f`)
+		case '\r':
+			result.WriteString(`\r`)
+		default:
+			switch {
+			case r >= 0x20 && r <= 0x7e:
+				result.WriteRune(r)
+			case r <= 0xffff:
+				fmt.Fprintf(&result, `\u%04x`, r)
+			default:
+				high, low := utf16.EncodeRune(r)
+				fmt.Fprintf(&result, `\u%04x\u%04x`, high, low)
+			}
+		}
+	}
+	result.WriteByte('"')
+	return result.String()
+}
+
+func pythonFloat(value float64) (string, error) {
+	if math.IsNaN(value) {
+		return "NaN", nil
+	}
+	if math.IsInf(value, 1) {
+		return "Infinity", nil
+	}
+	if math.IsInf(value, -1) {
+		return "-Infinity", nil
+	}
+	if value == 0 {
+		if math.Signbit(value) {
+			return "-0.0", nil
+		}
+		return "0.0", nil
+	}
+
+	formatted := strconv.FormatFloat(value, 'g', -1, 64)
+	exponentIndex := strings.IndexByte(formatted, 'e')
+	if exponentIndex == -1 {
+		if !strings.ContainsRune(formatted, '.') {
+			formatted += ".0"
+		}
+		return formatted, nil
+	}
+
+	mantissa := formatted[:exponentIndex]
+	exponent, err := strconv.Atoi(formatted[exponentIndex+1:])
+	if err != nil {
+		return "", fmt.Errorf("parse float exponent %q: %w", formatted, err)
+	}
+
+	if exponent >= -4 && exponent < 16 {
+		return expandFloat(mantissa, exponent), nil
+	}
+
+	exponentSign := "+"
+	if exponent < 0 {
+		exponentSign = "-"
+		exponent = -exponent
+	}
+	return mantissa + "e" + exponentSign + fmt.Sprintf("%02d", exponent), nil
+}
+
+func expandFloat(mantissa string, exponent int) string {
+	sign := ""
+	if strings.HasPrefix(mantissa, "-") {
+		sign = "-"
+		mantissa = strings.TrimPrefix(mantissa, "-")
+	}
+
+	digits := strings.ReplaceAll(mantissa, ".", "")
+	decimalPosition := exponent + 1
+	switch {
+	case decimalPosition <= 0:
+		return sign + "0." + strings.Repeat("0", -decimalPosition) + digits
+	case decimalPosition >= len(digits):
+		return sign + digits + strings.Repeat("0", decimalPosition-len(digits)) + ".0"
+	default:
+		return sign + digits[:decimalPosition] + "." + digits[decimalPosition:]
+	}
+}

--- a/sortfmt/writer.go
+++ b/sortfmt/writer.go
@@ -77,6 +77,10 @@ func (w *jsonWriter) writeMapping(node *yaml.Node, depth int) error {
 	w.writeString("{\n")
 	for i := 0; i < len(node.Content); i += 2 {
 		keyNode := node.Content[i]
+		valueNode := node.Content[i+1]
+		if keyNode == nil || valueNode == nil {
+			return errors.New("mapping contains a nil key or value")
+		}
 		if keyNode.Kind != yaml.ScalarNode || keyNode.Tag != "!!str" {
 			return errors.New("JSON object key must be a string")
 		}
@@ -84,7 +88,7 @@ func (w *jsonWriter) writeMapping(node *yaml.Node, depth int) error {
 		w.writeIndent(depth + 1)
 		w.writeString(quoteJSONString(keyNode.Value))
 		w.writeString(": ")
-		if err := w.writeNode(node.Content[i+1], depth+1); err != nil {
+		if err := w.writeNode(valueNode, depth+1); err != nil {
 			return err
 		}
 		if i+2 < len(node.Content) {
@@ -124,7 +128,11 @@ func (w *jsonWriter) writeScalar(node *yaml.Node) error {
 	case "!!str":
 		w.writeString(quoteJSONString(node.Value))
 	case "!!bool":
-		if node.Value == "true" {
+		value, err := boolValue(node.Value)
+		if err != nil {
+			return err
+		}
+		if value {
 			w.writeString("true")
 		} else {
 			w.writeString("false")


### PR DESCRIPTION
## Summary

- add an opt-in sortfmt package for deterministic JSON formatting
- prioritize common OpenAPI keys and alphabetize paths, properties, and schemas
- stable-sort required, parameters, oneOf, anyOf, and allOf while preserving other arrays
- preserve Python-compatible escaping, arbitrary-precision integers, and floating-point rendering

## Behavior

The formatter is intentionally separate from existing human-readable formatting. It accepts JSON and emits two-space-indented output with a trailing newline. Selected array order can affect downstream generation, so callers must opt in where stable output is desired.

Inputs must be valid UTF-8. Lone UTF-16 surrogate escapes are rejected instead of being silently replaced. Numeric overflow retains Python-compatible Infinity rendering; callers requiring strict JSON should provide finite OpenAPI numeric values.

## Validation

- CI=1 mise ci
- byte-for-byte differential checks across six OpenAPI documents
- 97.8% local sortfmt statement coverage and 96.68% Codecov patch coverage
- 21,921 fuzz executions covering JSON string preservation and idempotency
- idempotence and input-permutation coverage
- escaped Unicode, duplicate keys, large numbers, float boundaries, malformed nodes, and writer failures