### PR TITLE
test(sortfmt): remove external parity test

### DIFF
--- a/sortfmt/format_test.go
+++ b/sortfmt/format_test.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"math"
 	"os"
-	"os/exec"
 	"strings"
 	"testing"
 
@@ -264,29 +263,6 @@ func TestFormat_EdgeCaseGolden(t *testing.T) {
 	err = Format(bytes.NewReader(expected), &idempotent)
 	require.NoError(t, err, "reference-formatted output should be accepted")
 	assert.Equal(t, expected, idempotent.Bytes(), "reference-formatted output should be idempotent")
-}
-
-func TestFormat_ReferenceParity(t *testing.T) {
-	t.Parallel()
-
-	referenceScript := os.Getenv("SORTFMT_REFERENCE_SCRIPT")
-	referenceInput := os.Getenv("SORTFMT_REFERENCE_INPUT")
-	if referenceScript == "" || referenceInput == "" {
-		t.Skip("set SORTFMT_REFERENCE_SCRIPT and SORTFMT_REFERENCE_INPUT to run the differential test")
-	}
-
-	input, err := os.ReadFile(referenceInput)
-	require.NoError(t, err, "reference input should be readable")
-
-	command := exec.CommandContext(t.Context(), "python3", referenceScript)
-	command.Stdin = bytes.NewReader(input)
-	expected, err := command.Output()
-	require.NoError(t, err, "reference formatter should succeed")
-
-	var actual bytes.Buffer
-	err = Format(bytes.NewReader(input), &actual)
-	require.NoError(t, err, "Go formatter should succeed")
-	assert.Equal(t, expected, actual.Bytes(), "Go output should match the reference formatter byte-for-byte")
 }
 
 func TestPythonFloat_Success(t *testing.T) {


### PR DESCRIPTION
## Summary

- remove the opt-in parity test that depends on external paths and environment variables
- keep the formatter test suite self-contained

## Testing

- go test ./sortfmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the optional reference parity test from `sortfmt/format_test.go` to keep the test suite self-contained and deterministic. Previously the suite could compare against a Python reference when `SORTFMT_REFERENCE_SCRIPT` and `SORTFMT_REFERENCE_INPUT` were set; that differential test is now removed.

- Deletes TestFormat_ReferenceParity; other tests unchanged.
- No runtime behavior change; CI no longer depends on Python or external files.
- Run tests as usual: `go test ./sortfmt`.

<sup>Written for commit 79f544125d5d88e7097289d36f31b305537bf96b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/openapi/pull/242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

