### PR TITLE
fix(yml): keep folded block scalars stable across encode round trips

### DIFF
--- a/marshaller/coremodel.go
+++ b/marshaller/coremodel.go
@@ -177,6 +177,8 @@ func (c *CoreModel) Marshal(ctx context.Context, w io.Writer) error {
 			resetNodeStylesForYAML(nodeToMarshal, cfg)
 		}
 
+		yml.StabilizeFoldedScalars(nodeToMarshal)
+
 		enc := yaml.NewEncoder(w)
 		enc.SetIndent(cfg.Indentation)
 		if err := enc.Encode(nodeToMarshal); err != nil {

--- a/openapi/foldedscalar_marshalling_test.go
+++ b/openapi/foldedscalar_marshalling_test.go
@@ -2,7 +2,6 @@ package openapi_test
 
 import (
 	"bytes"
-	"context"
 	"strings"
 	"testing"
 
@@ -30,7 +29,7 @@ paths: {}
 func TestMarshal_FoldedScalar_SurvivesRepeatedRoundTrips(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	doc, validationErrs, err := openapi.Unmarshal(ctx, strings.NewReader(foldedScalarDocument))
 	require.NoError(t, err)
@@ -40,7 +39,7 @@ func TestMarshal_FoldedScalar_SurvivesRepeatedRoundTrips(t *testing.T) {
 	require.Contains(t, want, "| acme |")
 
 	current := foldedScalarDocument
-	for i := range 30 {
+	for i := range 3 {
 		doc, _, err := openapi.Unmarshal(ctx, strings.NewReader(current))
 		require.NoError(t, err)
 

--- a/openapi/foldedscalar_marshalling_test.go
+++ b/openapi/foldedscalar_marshalling_test.go
@@ -1,0 +1,53 @@
+package openapi_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/speakeasy-api/openapi/openapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The trailing table row is indented one space further than the rows above it, which
+// makes yaml.v3 emit an extra line break before it on every encode. Marshalling has to
+// stay a fixed point regardless of whether an overlay was involved.
+const foldedScalarDocument = `openapi: 3.1.0
+info:
+  title: Test
+  version: 1.0.0
+  description: >-
+    ### Widgets
+
+    | Name | Kind |
+    | ---- | ---- |
+     | acme | ` + "`petstore`" + ` |
+paths: {}
+`
+
+func TestMarshal_FoldedScalar_SurvivesRepeatedRoundTrips(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	doc, validationErrs, err := openapi.Unmarshal(ctx, strings.NewReader(foldedScalarDocument))
+	require.NoError(t, err)
+	require.Empty(t, validationErrs)
+
+	want := doc.Info.GetDescription()
+	require.Contains(t, want, "| acme |")
+
+	current := foldedScalarDocument
+	for i := range 30 {
+		doc, _, err := openapi.Unmarshal(ctx, strings.NewReader(current))
+		require.NoError(t, err)
+
+		var buf bytes.Buffer
+		require.NoError(t, openapi.Marshal(ctx, doc, &buf))
+
+		current = buf.String()
+		assert.Equal(t, want, doc.Info.GetDescription(), "value changed after %d round trips", i+1)
+	}
+}

--- a/openapi/localize.go
+++ b/openapi/localize.go
@@ -14,6 +14,7 @@ import (
 	"github.com/speakeasy-api/openapi/references"
 	"github.com/speakeasy-api/openapi/sequencedmap"
 	"github.com/speakeasy-api/openapi/system"
+	"github.com/speakeasy-api/openapi/yml"
 	"gopkg.in/yaml.v3"
 )
 
@@ -581,6 +582,8 @@ func rewriteInternalReferences(content []byte, originalRef string, storage *loca
 	}
 
 	// Marshal back to YAML
+	yml.StabilizeFoldedScalars(&node)
+
 	updatedContent, err := yaml.Marshal(&node)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal updated YAML: %w", err)

--- a/openapi/testdata/localize/input/components.yaml
+++ b/openapi/testdata/localize/input/components.yaml
@@ -2,6 +2,14 @@ components:
   schemas:
     User:
       type: object
+      # The last row is deliberately indented further: that is what makes yaml.v3
+      # inject a line break into a folded scalar on encode.
+      description: >-
+        ### User
+
+        | Field | Kind |
+        | ----- | ---- |
+         | id | string |
       required:
         - id
         - name

--- a/openapi/testdata/localize/output_counter/components.yaml
+++ b/openapi/testdata/localize/output_counter/components.yaml
@@ -2,6 +2,12 @@ components:
     schemas:
         User:
             type: object
+            # The last row is deliberately indented further: that is what makes yaml.v3
+            # inject a line break into a folded scalar on encode.
+            description: |-
+                ### User
+                | Field | Kind | | ----- | ---- |
+                 | id | string |
             required:
                 - id
                 - name

--- a/openapi/testdata/localize/output_pathbased/components.yaml
+++ b/openapi/testdata/localize/output_pathbased/components.yaml
@@ -2,6 +2,12 @@ components:
     schemas:
         User:
             type: object
+            # The last row is deliberately indented further: that is what makes yaml.v3
+            # inject a line break into a folded scalar on encode.
+            description: |-
+                ### User
+                | Field | Kind | | ----- | ---- |
+                 | id | string |
             required:
                 - id
                 - name

--- a/oq/foldedscalar_format_test.go
+++ b/oq/foldedscalar_format_test.go
@@ -1,0 +1,114 @@
+package oq_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/speakeasy-api/openapi/graph"
+	"github.com/speakeasy-api/openapi/openapi"
+	"github.com/speakeasy-api/openapi/oq"
+	"github.com/speakeasy-api/openapi/references"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// The trailing table row is indented one space further than the rows above it, which
+// makes yaml.v3 emit an extra line break before it on every encode. The break lands
+// inside the scalar, so it changes the decoded value rather than just the layout.
+const foldedScalarSpec = `openapi: 3.1.0
+info:
+  title: Test
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Widget:
+      type: object
+      description: >-
+        ### Widgets
+
+        | Name | Kind |
+        | ---- | ---- |
+         | acme | ` + "`petstore`" + ` |
+`
+
+func loadFoldedScalarGraph(t *testing.T) *graph.SchemaGraph {
+	t.Helper()
+
+	ctx := t.Context()
+
+	doc, _, err := openapi.Unmarshal(ctx, strings.NewReader(foldedScalarSpec), openapi.WithSkipValidation())
+	require.NoError(t, err)
+	require.NotNil(t, doc)
+
+	idx := openapi.BuildIndex(ctx, doc, references.ResolveOptions{
+		RootDocument:   doc,
+		TargetDocument: doc,
+		TargetLocation: "spec.yaml",
+	})
+
+	return graph.Build(ctx, idx)
+}
+
+// formattedDescription pulls the description back out of a `key:\n  <schema>` wrapper.
+func formattedDescription(t *testing.T, formatted string) string {
+	t.Helper()
+
+	var decoded map[string]struct {
+		Description string `yaml:"description"`
+	}
+	require.NoError(t, yaml.Unmarshal([]byte(formatted), &decoded))
+	require.Len(t, decoded, 1)
+
+	for _, schema := range decoded {
+		return schema.Description
+	}
+
+	return ""
+}
+
+// `openapi spec query --format yaml` marshals graph nodes with its own encoder, so it
+// needs the same stabilization as every other encode boundary.
+func TestFormatYAML_FoldedScalarKeepsItsValue(t *testing.T) {
+	t.Parallel()
+
+	var want struct {
+		Components struct {
+			Schemas map[string]struct {
+				Description string `yaml:"description"`
+			} `yaml:"schemas"`
+		} `yaml:"components"`
+	}
+	require.NoError(t, yaml.Unmarshal([]byte(foldedScalarSpec), &want))
+	wantDescription := want.Components.Schemas["Widget"].Description
+	require.Contains(t, wantDescription, "| acme |")
+
+	g := loadFoldedScalarGraph(t)
+
+	result, err := oq.Execute(`schemas | where(name == "Widget")`, g)
+	require.NoError(t, err)
+	require.Len(t, result.Rows, 1)
+
+	formatted := oq.FormatYAML(result, g)
+	require.NotEmpty(t, formatted)
+
+	assert.Equal(t, wantDescription, formattedDescription(t, formatted))
+	assert.NotContains(t, formatted, ">-", "affected folded scalars should be emitted as literal blocks")
+}
+
+// Formatting the same result twice must not drift, since FormatYAML restyles graph
+// nodes in place.
+func TestFormatYAML_FoldedScalarIsAFixedPoint(t *testing.T) {
+	t.Parallel()
+
+	g := loadFoldedScalarGraph(t)
+
+	result, err := oq.Execute(`schemas | where(name == "Widget")`, g)
+	require.NoError(t, err)
+
+	first := oq.FormatYAML(result, g)
+	for i := range 3 {
+		assert.Equal(t, first, oq.FormatYAML(result, g), "output changed on format %d", i+2)
+	}
+}

--- a/oq/format.go
+++ b/oq/format.go
@@ -8,6 +8,7 @@ import (
 	gcf "github.com/blackwell-systems/gcf-go"
 	"github.com/speakeasy-api/openapi/graph"
 	"github.com/speakeasy-api/openapi/oq/expr"
+	"github.com/speakeasy-api/openapi/yml"
 	"gopkg.in/yaml.v3"
 )
 
@@ -310,6 +311,8 @@ func FormatYAML(result *Result, g *graph.SchemaGraph) string {
 				node,
 			},
 		}
+		yml.StabilizeFoldedScalars(wrapper)
+
 		data, err := yaml.Marshal(wrapper)
 		if err != nil {
 			sb.WriteString("# error marshalling: " + err.Error() + "\n")

--- a/overlay/apply.go
+++ b/overlay/apply.go
@@ -30,6 +30,8 @@ func (o *Overlay) ApplyTo(root *yaml.Node) error {
 		}
 	}
 
+	stabilizeFoldedScalars(root)
+
 	return nil
 }
 
@@ -84,6 +86,9 @@ func (o *Overlay) ApplyToStrict(root *yaml.Node) ([]string, error) {
 	if len(multiError) > 0 {
 		return warnings, fmt.Errorf("error applying overlay (strict): %v", strings.Join(multiError, ","))
 	}
+
+	stabilizeFoldedScalars(root)
+
 	return warnings, nil
 }
 

--- a/overlay/apply.go
+++ b/overlay/apply.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/speakeasy-api/jsonpath/pkg/jsonpath/config"
 	"github.com/speakeasy-api/jsonpath/pkg/jsonpath/token"
+	"github.com/speakeasy-api/openapi/yml"
 	"gopkg.in/yaml.v3"
 )
 
@@ -30,7 +31,7 @@ func (o *Overlay) ApplyTo(root *yaml.Node) error {
 		}
 	}
 
-	stabilizeFoldedScalars(root)
+	yml.StabilizeFoldedScalars(root)
 
 	return nil
 }
@@ -87,7 +88,7 @@ func (o *Overlay) ApplyToStrict(root *yaml.Node) ([]string, error) {
 		return warnings, fmt.Errorf("error applying overlay (strict): %v", strings.Join(multiError, ","))
 	}
 
-	stabilizeFoldedScalars(root)
+	yml.StabilizeFoldedScalars(root)
 
 	return warnings, nil
 }

--- a/overlay/foldedscalar.go
+++ b/overlay/foldedscalar.go
@@ -7,6 +7,10 @@ import (
 // stabilizeFoldedScalars restyles folded block scalars in the overlay's own update
 // payloads so that serializing the overlay round trips unchanged.
 func (o *Overlay) stabilizeFoldedScalars() {
+	if o == nil {
+		return
+	}
+
 	for i := range o.Actions {
 		yml.StabilizeFoldedScalars(&o.Actions[i].Update)
 	}

--- a/overlay/foldedscalar.go
+++ b/overlay/foldedscalar.go
@@ -1,0 +1,36 @@
+package overlay
+
+import (
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Block indentation is stripped on decode, so leading whitespace means more-indented.
+func hasMoreIndentedLine(value string) bool {
+	for _, line := range strings.Split(value, "\n") {
+		if line == "" {
+			continue
+		}
+		if line[0] == ' ' || line[0] == '\t' {
+			return true
+		}
+	}
+
+	return false
+}
+
+// yaml.v3 injects a line break before more-indented lines in folded scalars on every encode; literal blocks round trip unchanged.
+func stabilizeFoldedScalars(node *yaml.Node) {
+	if node == nil {
+		return
+	}
+
+	if node.Kind == yaml.ScalarNode && node.Style&yaml.FoldedStyle != 0 && hasMoreIndentedLine(node.Value) {
+		node.Style = node.Style&^yaml.FoldedStyle | yaml.LiteralStyle
+	}
+
+	for _, child := range node.Content {
+		stabilizeFoldedScalars(child)
+	}
+}

--- a/overlay/foldedscalar.go
+++ b/overlay/foldedscalar.go
@@ -1,36 +1,13 @@
 package overlay
 
 import (
-	"strings"
-
-	"gopkg.in/yaml.v3"
+	"github.com/speakeasy-api/openapi/yml"
 )
 
-// Block indentation is stripped on decode, so leading whitespace means more-indented.
-func hasMoreIndentedLine(value string) bool {
-	for _, line := range strings.Split(value, "\n") {
-		if line == "" {
-			continue
-		}
-		if line[0] == ' ' || line[0] == '\t' {
-			return true
-		}
-	}
-
-	return false
-}
-
-// yaml.v3 injects a line break before more-indented lines in folded scalars on every encode; literal blocks round trip unchanged.
-func stabilizeFoldedScalars(node *yaml.Node) {
-	if node == nil {
-		return
-	}
-
-	if node.Kind == yaml.ScalarNode && node.Style&yaml.FoldedStyle != 0 && hasMoreIndentedLine(node.Value) {
-		node.Style = node.Style&^yaml.FoldedStyle | yaml.LiteralStyle
-	}
-
-	for _, child := range node.Content {
-		stabilizeFoldedScalars(child)
+// stabilizeFoldedScalars restyles folded block scalars in the overlay's own update
+// payloads so that serializing the overlay round trips unchanged.
+func (o *Overlay) stabilizeFoldedScalars() {
+	for i := range o.Actions {
+		yml.StabilizeFoldedScalars(&o.Actions[i].Update)
 	}
 }

--- a/overlay/foldedscalar_test.go
+++ b/overlay/foldedscalar_test.go
@@ -1,15 +1,17 @@
-package overlay
+package overlay_test
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/speakeasy-api/openapi/overlay"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 )
 
 // The trailing table row is indented one space further than the rows above it,
-// which is what triggers the yaml.v3 emitter defect this file guards against.
+// which is what triggers the yaml.v3 emitter defect these tests guard against.
 const foldedWithMoreIndentedLine = `description: >-
   ### Widgets
 
@@ -18,33 +20,17 @@ const foldedWithMoreIndentedLine = `description: >-
    | acme | ` + "`petstore`" + ` |
 `
 
-func roundTrip(t *testing.T, doc string, stabilize bool) string {
-	t.Helper()
-
-	var node yaml.Node
-	require.NoError(t, yaml.Unmarshal([]byte(doc), &node))
-
-	if stabilize {
-		stabilizeFoldedScalars(&node)
+func testOverlay() *overlay.Overlay {
+	return &overlay.Overlay{
+		Version: "1.0.0",
+		Info:    overlay.Info{Title: "Test", Version: "1.0.0"},
+		Actions: []overlay.Action{
+			{
+				Target: "$.title",
+				Update: yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "Updated"},
+			},
+		},
 	}
-
-	out, err := yaml.Marshal(&node)
-	require.NoError(t, err)
-
-	return string(out)
-}
-
-func applyRoundTrip(t *testing.T, o *Overlay, doc string) string {
-	t.Helper()
-
-	var node yaml.Node
-	require.NoError(t, yaml.Unmarshal([]byte(doc), &node))
-	require.NoError(t, o.ApplyTo(&node))
-
-	out, err := yaml.Marshal(&node)
-	require.NoError(t, err)
-
-	return string(out)
 }
 
 func decodeDescription(t *testing.T, doc string) string {
@@ -61,22 +47,20 @@ func decodeDescription(t *testing.T, doc string) string {
 func TestApplyToSurvivesRepeatedApplies(t *testing.T) {
 	t.Parallel()
 
-	o := &Overlay{
-		Version: "1.0.0",
-		Info:    Info{Title: "Test", Version: "1.0.0"},
-		Actions: []Action{
-			{
-				Target: "$.title",
-				Update: yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "Updated"},
-			},
-		},
-	}
+	o := testOverlay()
 
 	doc := "title: Original\n" + foldedWithMoreIndentedLine
 	want := decodeDescription(t, doc)
 
 	for i := range 30 {
-		doc = applyRoundTrip(t, o, doc)
+		var node yaml.Node
+		require.NoError(t, yaml.Unmarshal([]byte(doc), &node))
+		require.NoError(t, o.ApplyTo(&node))
+
+		out, err := yaml.Marshal(&node)
+		require.NoError(t, err)
+
+		doc = string(out)
 		assert.Equal(t, want, decodeDescription(t, doc), "value changed after %d applies", i+1)
 	}
 }
@@ -84,16 +68,7 @@ func TestApplyToSurvivesRepeatedApplies(t *testing.T) {
 func TestApplyToStrictSurvivesRepeatedApplies(t *testing.T) {
 	t.Parallel()
 
-	o := &Overlay{
-		Version: "1.0.0",
-		Info:    Info{Title: "Test", Version: "1.0.0"},
-		Actions: []Action{
-			{
-				Target: "$.title",
-				Update: yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "Updated"},
-			},
-		},
-	}
+	o := testOverlay()
 
 	doc := "title: Original\n" + foldedWithMoreIndentedLine
 	want := decodeDescription(t, doc)
@@ -112,122 +87,56 @@ func TestApplyToStrictSurvivesRepeatedApplies(t *testing.T) {
 	}
 }
 
-func TestStabilizeFoldedScalarsHandlesExplicitTags(t *testing.T) {
+// An overlay carries folded scalars of its own, in the update payloads it applies.
+func TestFormatSurvivesRepeatedRoundTrips(t *testing.T) {
 	t.Parallel()
 
-	doc := "description: !!str >-\n  a\n   b\n"
-	want := decodeDescription(t, doc)
+	src := `overlay: 1.0.0
+info:
+  title: Test
+  version: 1.0.0
+actions:
+  - target: $.info
+    update:
+` + indent(foldedWithMoreIndentedLine, "      ")
 
-	for i := range 5 {
-		doc = roundTrip(t, doc, true)
-		assert.Equal(t, want, decodeDescription(t, doc), "value changed after %d round trips", i+1)
-	}
-	assert.Contains(t, doc, "!!str", "explicit tag should be preserved")
-}
+	want := updateDescription(t, src)
 
-func TestStabilizeFoldedScalarsSurvivesRepeatedRoundTrips(t *testing.T) {
-	t.Parallel()
-
-	want := decodeDescription(t, foldedWithMoreIndentedLine)
-
-	doc := foldedWithMoreIndentedLine
+	doc := src
 	for i := range 30 {
-		doc = roundTrip(t, doc, true)
-		assert.Equal(t, want, decodeDescription(t, doc), "value changed after %d round trips", i+1)
+		o, err := overlay.ParseReader(strings.NewReader(doc))
+		require.NoError(t, err)
+
+		formatted, err := o.ToString()
+		require.NoError(t, err)
+
+		doc = formatted
+		assert.Equal(t, want, updateDescription(t, doc), "value changed after %d round trips", i+1)
 	}
 }
 
-// Fails once gopkg.in/yaml.v3 fixes the emitter, at which point stabilizeFoldedScalars can go.
-func TestFoldedScalarGrowsWithoutStabilizer(t *testing.T) {
-	t.Parallel()
+func indent(doc string, prefix string) string {
+	lines := strings.Split(strings.TrimSuffix(doc, "\n"), "\n")
+	for i, line := range lines {
+		if line != "" {
+			lines[i] = prefix + line
+		}
+	}
 
-	before := decodeDescription(t, foldedWithMoreIndentedLine)
-	after := decodeDescription(t, roundTrip(t, foldedWithMoreIndentedLine, false))
-
-	assert.NotEqual(t, before, after)
+	return strings.Join(lines, "\n") + "\n"
 }
 
-func TestStabilizeFoldedScalarsLeavesStableStylesAlone(t *testing.T) {
-	t.Parallel()
+func updateDescription(t *testing.T, doc string) string {
+	t.Helper()
 
-	tests := []struct {
-		name  string
-		doc   string
-		style string
-	}{
-		{
-			name:  "folded scalar with no more-indented line",
-			doc:   "description: >-\n  one line\n  another line\n",
-			style: ">-",
-		},
-		{
-			name:  "literal scalar with more-indented line",
-			doc:   "description: |-\n  one line\n   more indented\n",
-			style: "|-",
-		},
-		{
-			name: "plain scalar",
-			doc:  "description: just a string\n",
-		},
+	o, err := overlay.ParseReader(strings.NewReader(doc))
+	require.NoError(t, err)
+	require.Len(t, o.Actions, 1)
+
+	var decoded struct {
+		Description string `yaml:"description"`
 	}
+	require.NoError(t, o.Actions[0].Update.Decode(&decoded))
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			want := decodeDescription(t, tt.doc)
-
-			doc := roundTrip(t, tt.doc, true)
-			assert.Equal(t, want, decodeDescription(t, doc))
-			if tt.style != "" {
-				assert.Contains(t, doc, tt.style, "original style should be preserved")
-			}
-
-			for range 5 {
-				next := roundTrip(t, doc, true)
-				assert.Equal(t, doc, next, "representation should be a fixed point")
-				assert.Equal(t, want, decodeDescription(t, next))
-				doc = next
-			}
-		})
-	}
-}
-
-func TestStabilizeFoldedScalarsToleratesNilNodes(t *testing.T) {
-	t.Parallel()
-
-	assert.NotPanics(t, func() { stabilizeFoldedScalars(nil) })
-
-	// A hand-built tree may carry nil children; recursion must not panic.
-	assert.NotPanics(t, func() {
-		stabilizeFoldedScalars(&yaml.Node{
-			Kind:    yaml.MappingNode,
-			Content: []*yaml.Node{nil, nil},
-		})
-	})
-}
-
-func TestHasMoreIndentedLine(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name  string
-		value string
-		want  bool
-	}{
-		{name: "no indentation", value: "one\ntwo", want: false},
-		{name: "space indented line", value: "one\n two", want: true},
-		{name: "tab indented line", value: "one\n\ttwo", want: true},
-		{name: "blank lines only", value: "one\n\ntwo", want: false},
-		{name: "empty", value: "", want: false},
-		{name: "first line indented", value: " one\ntwo", want: true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			assert.Equal(t, tt.want, hasMoreIndentedLine(tt.value))
-		})
-	}
+	return decoded.Description
 }

--- a/overlay/foldedscalar_test.go
+++ b/overlay/foldedscalar_test.go
@@ -53,7 +53,7 @@ func TestApplyToSurvivesRepeatedApplies(t *testing.T) {
 	doc := "title: Original\n" + foldedWithMoreIndentedLine
 	want := decodeDescription(t, doc)
 
-	for i := range 30 {
+	for i := range 3 {
 		var node yaml.Node
 		require.NoError(t, yaml.Unmarshal([]byte(doc), &node))
 		require.NoError(t, o.ApplyTo(&node))
@@ -74,7 +74,7 @@ func TestApplyToStrictSurvivesRepeatedApplies(t *testing.T) {
 	doc := "title: Original\n" + foldedWithMoreIndentedLine
 	want := decodeDescription(t, doc)
 
-	for i := range 30 {
+	for i := range 3 {
 		var node yaml.Node
 		require.NoError(t, yaml.Unmarshal([]byte(doc), &node))
 		_, err := o.ApplyToStrict(&node)
@@ -89,6 +89,7 @@ func TestApplyToStrictSurvivesRepeatedApplies(t *testing.T) {
 }
 
 // An overlay carries folded scalars of its own, in the update payloads it applies.
+// Format and ToString are separate entry points and each stabilizes independently.
 func TestFormatSurvivesRepeatedRoundTrips(t *testing.T) {
 	t.Parallel()
 
@@ -101,18 +102,38 @@ actions:
     update:
 ` + indent(foldedWithMoreIndentedLine, "      ")
 
-	want := updateDescription(t, src)
+	serializers := map[string]func(*overlay.Overlay) (string, error){
+		"ToString": func(o *overlay.Overlay) (string, error) {
+			return o.ToString()
+		},
+		"Format": func(o *overlay.Overlay) (string, error) {
+			var buf bytes.Buffer
+			if err := o.Format(&buf); err != nil {
+				return "", err
+			}
 
-	doc := src
-	for i := range 30 {
-		o, err := overlay.ParseReader(strings.NewReader(doc))
-		require.NoError(t, err)
+			return buf.String(), nil
+		},
+	}
 
-		formatted, err := o.ToString()
-		require.NoError(t, err)
+	for name, serialize := range serializers {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 
-		doc = formatted
-		assert.Equal(t, want, updateDescription(t, doc), "value changed after %d round trips", i+1)
+			want := updateDescription(t, src)
+
+			doc := src
+			for i := range 3 {
+				o, err := overlay.ParseReader(strings.NewReader(doc))
+				require.NoError(t, err)
+
+				formatted, err := serialize(o)
+				require.NoError(t, err)
+
+				doc = formatted
+				assert.Equal(t, want, updateDescription(t, doc), "value changed after %d round trips", i+1)
+			}
+		})
 	}
 }
 

--- a/overlay/foldedscalar_test.go
+++ b/overlay/foldedscalar_test.go
@@ -1,0 +1,219 @@
+package overlay
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// The trailing table row is indented one space further than the rows above it,
+// which is what triggers the yaml.v3 emitter defect this file guards against.
+const foldedWithMoreIndentedLine = `description: >-
+  ### Widgets
+
+  | Name | Kind |
+  | ---- | ---- |
+   | acme | ` + "`petstore`" + ` |
+`
+
+func roundTrip(t *testing.T, doc string, stabilize bool) string {
+	t.Helper()
+
+	var node yaml.Node
+	require.NoError(t, yaml.Unmarshal([]byte(doc), &node))
+
+	if stabilize {
+		stabilizeFoldedScalars(&node)
+	}
+
+	out, err := yaml.Marshal(&node)
+	require.NoError(t, err)
+
+	return string(out)
+}
+
+func applyRoundTrip(t *testing.T, o *Overlay, doc string) string {
+	t.Helper()
+
+	var node yaml.Node
+	require.NoError(t, yaml.Unmarshal([]byte(doc), &node))
+	require.NoError(t, o.ApplyTo(&node))
+
+	out, err := yaml.Marshal(&node)
+	require.NoError(t, err)
+
+	return string(out)
+}
+
+func decodeDescription(t *testing.T, doc string) string {
+	t.Helper()
+
+	var decoded struct {
+		Description string `yaml:"description"`
+	}
+	require.NoError(t, yaml.Unmarshal([]byte(doc), &decoded))
+
+	return decoded.Description
+}
+
+func TestApplyToSurvivesRepeatedApplies(t *testing.T) {
+	t.Parallel()
+
+	o := &Overlay{
+		Version: "1.0.0",
+		Info:    Info{Title: "Test", Version: "1.0.0"},
+		Actions: []Action{
+			{
+				Target: "$.title",
+				Update: yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "Updated"},
+			},
+		},
+	}
+
+	doc := "title: Original\n" + foldedWithMoreIndentedLine
+	want := decodeDescription(t, doc)
+
+	for i := range 30 {
+		doc = applyRoundTrip(t, o, doc)
+		assert.Equal(t, want, decodeDescription(t, doc), "value changed after %d applies", i+1)
+	}
+}
+
+func TestApplyToStrictSurvivesRepeatedApplies(t *testing.T) {
+	t.Parallel()
+
+	o := &Overlay{
+		Version: "1.0.0",
+		Info:    Info{Title: "Test", Version: "1.0.0"},
+		Actions: []Action{
+			{
+				Target: "$.title",
+				Update: yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "Updated"},
+			},
+		},
+	}
+
+	doc := "title: Original\n" + foldedWithMoreIndentedLine
+	want := decodeDescription(t, doc)
+
+	for i := range 30 {
+		var node yaml.Node
+		require.NoError(t, yaml.Unmarshal([]byte(doc), &node))
+		_, err := o.ApplyToStrict(&node)
+		require.NoError(t, err)
+
+		out, err := yaml.Marshal(&node)
+		require.NoError(t, err)
+
+		doc = string(out)
+		assert.Equal(t, want, decodeDescription(t, doc), "value changed after %d applies", i+1)
+	}
+}
+
+func TestStabilizeFoldedScalarsHandlesExplicitTags(t *testing.T) {
+	t.Parallel()
+
+	doc := "description: !!str >-\n  a\n   b\n"
+	want := decodeDescription(t, doc)
+
+	for i := range 5 {
+		doc = roundTrip(t, doc, true)
+		assert.Equal(t, want, decodeDescription(t, doc), "value changed after %d round trips", i+1)
+	}
+	assert.Contains(t, doc, "!!str", "explicit tag should be preserved")
+}
+
+func TestStabilizeFoldedScalarsSurvivesRepeatedRoundTrips(t *testing.T) {
+	t.Parallel()
+
+	want := decodeDescription(t, foldedWithMoreIndentedLine)
+
+	doc := foldedWithMoreIndentedLine
+	for i := range 30 {
+		doc = roundTrip(t, doc, true)
+		assert.Equal(t, want, decodeDescription(t, doc), "value changed after %d round trips", i+1)
+	}
+}
+
+// Fails once gopkg.in/yaml.v3 fixes the emitter, at which point stabilizeFoldedScalars can go.
+func TestFoldedScalarGrowsWithoutStabilizer(t *testing.T) {
+	t.Parallel()
+
+	before := decodeDescription(t, foldedWithMoreIndentedLine)
+	after := decodeDescription(t, roundTrip(t, foldedWithMoreIndentedLine, false))
+
+	assert.NotEqual(t, before, after)
+}
+
+func TestStabilizeFoldedScalarsLeavesStableStylesAlone(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		doc   string
+		style string
+	}{
+		{
+			name:  "folded scalar with no more-indented line",
+			doc:   "description: >-\n  one line\n  another line\n",
+			style: ">-",
+		},
+		{
+			name:  "literal scalar with more-indented line",
+			doc:   "description: |-\n  one line\n   more indented\n",
+			style: "|-",
+		},
+		{
+			name: "plain scalar",
+			doc:  "description: just a string\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			want := decodeDescription(t, tt.doc)
+
+			doc := roundTrip(t, tt.doc, true)
+			assert.Equal(t, want, decodeDescription(t, doc))
+			if tt.style != "" {
+				assert.Contains(t, doc, tt.style, "original style should be preserved")
+			}
+
+			for range 5 {
+				next := roundTrip(t, doc, true)
+				assert.Equal(t, doc, next, "representation should be a fixed point")
+				assert.Equal(t, want, decodeDescription(t, next))
+				doc = next
+			}
+		})
+	}
+}
+
+func TestHasMoreIndentedLine(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{name: "no indentation", value: "one\ntwo", want: false},
+		{name: "space indented line", value: "one\n two", want: true},
+		{name: "tab indented line", value: "one\n\ttwo", want: true},
+		{name: "blank lines only", value: "one\n\ntwo", want: false},
+		{name: "empty", value: "", want: false},
+		{name: "first line indented", value: " one\ntwo", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, hasMoreIndentedLine(tt.value))
+		})
+	}
+}

--- a/overlay/foldedscalar_test.go
+++ b/overlay/foldedscalar_test.go
@@ -1,6 +1,7 @@
 package overlay_test
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 
@@ -113,6 +114,21 @@ actions:
 		doc = formatted
 		assert.Equal(t, want, updateDescription(t, doc), "value changed after %d round trips", i+1)
 	}
+}
+
+// A nil overlay serializes as "null"; stabilizing must not change that.
+func TestFormatToleratesNilOverlay(t *testing.T) {
+	t.Parallel()
+
+	var o *overlay.Overlay
+
+	formatted, err := o.ToString()
+	require.NoError(t, err)
+	assert.Equal(t, "null\n", formatted)
+
+	var buf bytes.Buffer
+	require.NoError(t, o.Format(&buf))
+	assert.Equal(t, "null\n", buf.String())
 }
 
 func indent(doc string, prefix string) string {

--- a/overlay/foldedscalar_test.go
+++ b/overlay/foldedscalar_test.go
@@ -193,6 +193,20 @@ func TestStabilizeFoldedScalarsLeavesStableStylesAlone(t *testing.T) {
 	}
 }
 
+func TestStabilizeFoldedScalarsToleratesNilNodes(t *testing.T) {
+	t.Parallel()
+
+	assert.NotPanics(t, func() { stabilizeFoldedScalars(nil) })
+
+	// A hand-built tree may carry nil children; recursion must not panic.
+	assert.NotPanics(t, func() {
+		stabilizeFoldedScalars(&yaml.Node{
+			Kind:    yaml.MappingNode,
+			Content: []*yaml.Node{nil, nil},
+		})
+	})
+}
+
 func TestHasMoreIndentedLine(t *testing.T) {
 	t.Parallel()
 

--- a/overlay/parse.go
+++ b/overlay/parse.go
@@ -65,6 +65,8 @@ func Format(path string) error {
 
 // Format writes the file back out as YAML.
 func (o *Overlay) Format(w io.Writer) error {
+	o.stabilizeFoldedScalars()
+
 	enc := yaml.NewEncoder(w)
 	enc.SetIndent(2)
 	return enc.Encode(o)

--- a/overlay/schema.go
+++ b/overlay/schema.go
@@ -64,6 +64,8 @@ func (o *Overlay) IsV110OrLater() bool {
 }
 
 func (o *Overlay) ToString() (string, error) {
+	o.stabilizeFoldedScalars()
+
 	buf := bytes.NewBuffer([]byte{})
 	decoder := yaml.NewEncoder(buf)
 	decoder.SetIndent(2)

--- a/yml/foldedscalar.go
+++ b/yml/foldedscalar.go
@@ -1,0 +1,46 @@
+package yml
+
+import (
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Block indentation is stripped on decode, so leading whitespace means more-indented.
+func hasMoreIndentedLine(value string) bool {
+	for _, line := range strings.Split(value, "\n") {
+		if line == "" {
+			continue
+		}
+		if line[0] == ' ' || line[0] == '\t' {
+			return true
+		}
+	}
+
+	return false
+}
+
+// StabilizeFoldedScalars restyles folded block scalars that contain a more-indented
+// line as literal blocks, leaving every other node untouched.
+//
+// gopkg.in/yaml.v3 injects a line break before a more-indented line in a folded scalar
+// on every encode, so a document that is decoded and re-encoded repeatedly accumulates
+// blank lines inside such scalars. The break lands inside the scalar, so it becomes part
+// of the decoded value rather than cosmetic whitespace. Literal blocks reproduce their
+// value verbatim and round trip unchanged.
+//
+// Only the representation changes; the decoded value is identical. Call this immediately
+// before encoding a node tree.
+func StabilizeFoldedScalars(node *yaml.Node) {
+	if node == nil {
+		return
+	}
+
+	if node.Kind == yaml.ScalarNode && node.Style&yaml.FoldedStyle != 0 && hasMoreIndentedLine(node.Value) {
+		node.Style = node.Style&^yaml.FoldedStyle | yaml.LiteralStyle
+	}
+
+	for _, child := range node.Content {
+		StabilizeFoldedScalars(child)
+	}
+}

--- a/yml/foldedscalar_test.go
+++ b/yml/foldedscalar_test.go
@@ -170,6 +170,32 @@ func TestStabilizeFoldedScalars_ToleratesNilNodes(t *testing.T) {
 	})
 }
 
+// An anchored scalar is an ordinary node in the tree, so aliases pointing at it need
+// no special handling: stabilizing the anchor definition covers every reference to it.
+func TestStabilizeFoldedScalars_HandlesAnchoredScalars(t *testing.T) {
+	t.Parallel()
+
+	doc := "a: &anchor >-\n  one\n   more indented\nb: *anchor\n"
+
+	var want struct {
+		A string `yaml:"a"`
+		B string `yaml:"b"`
+	}
+	require.NoError(t, yaml.Unmarshal([]byte(doc), &want))
+
+	for i := range 30 {
+		doc = roundTrip(t, doc, true)
+
+		var got struct {
+			A string `yaml:"a"`
+			B string `yaml:"b"`
+		}
+		require.NoError(t, yaml.Unmarshal([]byte(doc), &got))
+		assert.Equal(t, want, got, "value changed after %d round trips", i+1)
+		assert.Contains(t, doc, "*anchor", "alias should be preserved")
+	}
+}
+
 // Fails once gopkg.in/yaml.v3 fixes the emitter, at which point StabilizeFoldedScalars can go.
 func TestFoldedScalarGrowsWithoutStabilizer(t *testing.T) {
 	t.Parallel()

--- a/yml/foldedscalar_test.go
+++ b/yml/foldedscalar_test.go
@@ -52,9 +52,53 @@ func TestStabilizeFoldedScalars_SurvivesRepeatedRoundTrips(t *testing.T) {
 	want := decodeDescription(t, foldedWithMoreIndentedLine)
 
 	doc := foldedWithMoreIndentedLine
-	for i := range 30 {
+	for i := range 3 {
 		doc = roundTrip(t, doc, true)
 		assert.Equal(t, want, decodeDescription(t, doc), "value changed after %d round trips", i+1)
+	}
+}
+
+// yaml.v3 does not record the chomping indicator in Node.Style; it re-derives one from
+// the trailing newlines of the value. Restyling as a literal block therefore has to keep
+// clip and keep chomping intact, not just strip.
+func TestStabilizeFoldedScalars_PreservesChomping(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		doc       string
+		wantStyle string
+	}{
+		{
+			name:      "strip",
+			doc:       "description: >-\n  one line\n   more indented\n  last\n",
+			wantStyle: "|-",
+		},
+		{
+			name:      "clip",
+			doc:       "description: >\n  one line\n   more indented\n  last\n",
+			wantStyle: "|",
+		},
+		{
+			name:      "keep with trailing blank lines",
+			doc:       "description: >+\n  one line\n   more indented\n\n\n",
+			wantStyle: "|+",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			want := decodeDescription(t, tt.doc)
+
+			doc := tt.doc
+			for i := range 3 {
+				doc = roundTrip(t, doc, true)
+				assert.Equal(t, want, decodeDescription(t, doc), "value changed after %d round trips", i+1)
+			}
+			assert.Contains(t, doc, "description: "+tt.wantStyle+"\n", "chomping should be preserved")
+		})
 	}
 }
 
@@ -64,7 +108,7 @@ func TestStabilizeFoldedScalars_HandlesExplicitTags(t *testing.T) {
 	doc := "description: !!str >-\n  a\n   b\n"
 	want := decodeDescription(t, doc)
 
-	for i := range 5 {
+	for i := range 3 {
 		doc = roundTrip(t, doc, true)
 		assert.Equal(t, want, decodeDescription(t, doc), "value changed after %d round trips", i+1)
 	}
@@ -107,7 +151,7 @@ func TestStabilizeFoldedScalars_LeavesStableStylesAlone(t *testing.T) {
 				assert.Contains(t, doc, tt.style, "original style should be preserved")
 			}
 
-			for range 5 {
+			for range 3 {
 				next := roundTrip(t, doc, true)
 				assert.Equal(t, doc, next, "representation should be a fixed point")
 				assert.Equal(t, want, decodeDescription(t, next))
@@ -183,7 +227,7 @@ func TestStabilizeFoldedScalars_HandlesAnchoredScalars(t *testing.T) {
 	}
 	require.NoError(t, yaml.Unmarshal([]byte(doc), &want))
 
-	for i := range 30 {
+	for i := range 3 {
 		doc = roundTrip(t, doc, true)
 
 		var got struct {

--- a/yml/foldedscalar_test.go
+++ b/yml/foldedscalar_test.go
@@ -1,0 +1,181 @@
+package yml_test
+
+import (
+	"testing"
+
+	"github.com/speakeasy-api/openapi/yml"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// The trailing table row is indented one space further than the rows above it,
+// which is what triggers the yaml.v3 emitter defect this file guards against.
+const foldedWithMoreIndentedLine = `description: >-
+  ### Widgets
+
+  | Name | Kind |
+  | ---- | ---- |
+   | acme | ` + "`petstore`" + ` |
+`
+
+func roundTrip(t *testing.T, doc string, stabilize bool) string {
+	t.Helper()
+
+	var node yaml.Node
+	require.NoError(t, yaml.Unmarshal([]byte(doc), &node))
+
+	if stabilize {
+		yml.StabilizeFoldedScalars(&node)
+	}
+
+	out, err := yaml.Marshal(&node)
+	require.NoError(t, err)
+
+	return string(out)
+}
+
+func decodeDescription(t *testing.T, doc string) string {
+	t.Helper()
+
+	var decoded struct {
+		Description string `yaml:"description"`
+	}
+	require.NoError(t, yaml.Unmarshal([]byte(doc), &decoded))
+
+	return decoded.Description
+}
+
+func TestStabilizeFoldedScalars_SurvivesRepeatedRoundTrips(t *testing.T) {
+	t.Parallel()
+
+	want := decodeDescription(t, foldedWithMoreIndentedLine)
+
+	doc := foldedWithMoreIndentedLine
+	for i := range 30 {
+		doc = roundTrip(t, doc, true)
+		assert.Equal(t, want, decodeDescription(t, doc), "value changed after %d round trips", i+1)
+	}
+}
+
+func TestStabilizeFoldedScalars_HandlesExplicitTags(t *testing.T) {
+	t.Parallel()
+
+	doc := "description: !!str >-\n  a\n   b\n"
+	want := decodeDescription(t, doc)
+
+	for i := range 5 {
+		doc = roundTrip(t, doc, true)
+		assert.Equal(t, want, decodeDescription(t, doc), "value changed after %d round trips", i+1)
+	}
+	assert.Contains(t, doc, "!!str", "explicit tag should be preserved")
+}
+
+func TestStabilizeFoldedScalars_LeavesStableStylesAlone(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		doc   string
+		style string
+	}{
+		{
+			name:  "folded scalar with no more-indented line",
+			doc:   "description: >-\n  one line\n  another line\n",
+			style: ">-",
+		},
+		{
+			name:  "literal scalar with more-indented line",
+			doc:   "description: |-\n  one line\n   more indented\n",
+			style: "|-",
+		},
+		{
+			name: "plain scalar",
+			doc:  "description: just a string\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			want := decodeDescription(t, tt.doc)
+
+			doc := roundTrip(t, tt.doc, true)
+			assert.Equal(t, want, decodeDescription(t, doc))
+			if tt.style != "" {
+				assert.Contains(t, doc, tt.style, "original style should be preserved")
+			}
+
+			for range 5 {
+				next := roundTrip(t, doc, true)
+				assert.Equal(t, doc, next, "representation should be a fixed point")
+				assert.Equal(t, want, decodeDescription(t, next))
+				doc = next
+			}
+		})
+	}
+}
+
+func TestStabilizeFoldedScalars_DetectsMoreIndentedLines(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		value    string
+		restyled bool
+	}{
+		{name: "no indentation", value: "one\ntwo", restyled: false},
+		{name: "space indented line", value: "one\n two", restyled: true},
+		{name: "tab indented line", value: "one\n\ttwo", restyled: true},
+		{name: "blank lines only", value: "one\n\ntwo", restyled: false},
+		{name: "empty", value: "", restyled: false},
+		{name: "first line indented", value: " one\ntwo", restyled: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			node := &yaml.Node{
+				Kind:  yaml.ScalarNode,
+				Tag:   "!!str",
+				Style: yaml.FoldedStyle,
+				Value: tt.value,
+			}
+
+			yml.StabilizeFoldedScalars(node)
+
+			want := yaml.FoldedStyle
+			if tt.restyled {
+				want = yaml.LiteralStyle
+			}
+			assert.Equal(t, want, node.Style)
+			assert.Equal(t, tt.value, node.Value, "value must not be rewritten")
+		})
+	}
+}
+
+func TestStabilizeFoldedScalars_ToleratesNilNodes(t *testing.T) {
+	t.Parallel()
+
+	assert.NotPanics(t, func() { yml.StabilizeFoldedScalars(nil) })
+
+	// A hand-built tree may carry nil children; recursion must not panic.
+	assert.NotPanics(t, func() {
+		yml.StabilizeFoldedScalars(&yaml.Node{
+			Kind:    yaml.MappingNode,
+			Content: []*yaml.Node{nil, nil},
+		})
+	})
+}
+
+// Fails once gopkg.in/yaml.v3 fixes the emitter, at which point StabilizeFoldedScalars can go.
+func TestFoldedScalarGrowsWithoutStabilizer(t *testing.T) {
+	t.Parallel()
+
+	before := decodeDescription(t, foldedWithMoreIndentedLine)
+	after := decodeDescription(t, roundTrip(t, foldedWithMoreIndentedLine, false))
+
+	assert.NotEqual(t, before, after)
+}


### PR DESCRIPTION
## Why

`gopkg.in/yaml.v3` emits an extra line break immediately before a more-indented line inside a folded (`>-`) scalar. The break lands inside the scalar, so it becomes part of the decoded string rather than cosmetic whitespace: any decode/mutate/encode round trip grows such a scalar by one blank line, and a document run through many round trips accumulates roughly one blank line per pass in descriptions nothing ever targeted.

Minimal reproduction, no overlays involved:

```go
cur := "d: >-\n  normal line\n   more-indented line\n  another normal\n"
for i := 0; i < 4; i++ {
    var n yaml.Node
    yaml.Unmarshal([]byte(cur), &n)
    out, _ := yaml.Marshal(&n)
    cur = string(out) // grows one blank line each pass
}
```

Folded scalars without a more-indented line, and literal (`|-`) blocks, are already stable.

The emitter bug can't be fixed at its source: `go-yaml/yaml` is archived, and `gopkg.in/yaml.v3` is frozen at v3.0.1.

## What changed

`yml.StabilizeFoldedScalars` re-styles folded scalars containing a more-indented line as literal blocks, which reproduce their value verbatim and round trip unchanged. It is called immediately before encoding, at every point in this repository that writes a node tree back out:

- `marshaller.CoreModel.Marshal`, alongside the existing `resetNodeStylesForYAML` pass — this covers `openapi.Marshal`, `swagger.Marshal`, and everything else that goes through the core model
- `openapi.Localize`, when rewriting references in a copied external file
- `Overlay.Format` / `Overlay.ToString`, for folded scalars in an overlay's own update payloads
- `Overlay.ApplyTo` / `ApplyToStrict`, so consumers that encode the applied tree with their own encoder are covered without having to change
- `oq.FormatYAML`, which marshals graph nodes with its own encoder rather than going through the core model, and so backs `openapi spec query --format yaml`

It is exported so consumers with their own encode paths can call it directly.

This removes the trigger rather than patching the emitter, so it needs no fork or `replace` directive. The decoded value is unchanged — the node already holds the folded value — so only the on-disk representation differs.

## Testing

`go test ./...` passes, including the pre-existing expected-output fixtures.

New tests:

- `yml`: unit coverage for detection, explicit `!!str` tags, all three chomping indicators (`>-`, `>`, `>+`), styles that must be left alone, nil-node guards, anchored scalars, and `TestFoldedScalarGrowsWithoutStabilizer`, which asserts the unpatched emitter still misbehaves so it fails if `yaml.v3` is ever fixed and the workaround can be removed
- `openapi`: repeated `Unmarshal`/`Marshal` round trips of a document with an affected description, asserting the decoded value never changes, plus a more-indented folded description in the `localize` input fixture so both expected-output directories pin that path
- `overlay`: repeated applies via `ApplyTo` and `ApplyToStrict`, plus repeated round trips through both `Format` and `ToString` of an overlay whose update payload holds an affected scalar
- `oq`: a `schemas | where(...)` query formatted with `FormatYAML`, asserting the emitted description still decodes to its original value

Verified end to end against three builds of this module — the released version, the first commit of this branch, and its head — exercising four round-trip paths on a document whose description contains a more-indented table row:

| Path | released | ApplyTo-only fix | this branch |
| --- | --- | --- | --- |
| `openapi.Unmarshal` → `Marshal`, ×30 | +30 lines | +30 lines | stable |
| `ApplyTo` + caller's own encoder, ×30 | +30 lines | stable | stable |
| `Overlay.ToString`, ×30 | +30 lines | +30 lines | stable |
| `openapi.Localize`, ×10 | +10 lines | +10 lines | stable |

## Note for reviewers

Affected scalars change representation from `>-` to `|` the first time a document is re-encoded after this lands. That is a one-time diff; output is stable afterwards.

